### PR TITLE
ROX-27350: Fix `update-tasks-trust`

### DIFF
--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -558,8 +558,11 @@ spec:
             set -euo pipefail
 
             trust_image_tag="$(params.TRUST_IMAGE_TAG)"
+
             trust_image_repo="$(params.TRUST_IMAGE_REPO)"
             trust_image_repo_no_quay_io="${trust_image_repo#quay.io}"
+
+            trust_image_ref="${trust_image_repo}:${trust_image_tag}"
 
             trust_image_remote_tag_name="$( curl --silent --show-error --fail --location \
                 --get --data-urlencode "specificTag=${trust_image_tag}" \
@@ -586,13 +589,15 @@ spec:
             # that.
             #
             if [[ "${trust_image_remote_tag_name}" != "null" ]]; then
+              echo ">>> ${trust_image_ref} exists and will be updated"
               ec --debug track bundle --freshen \
                 --bundle "$(params.BUNDLE_REF)" \
-                --input "oci:${trust_image_repo}:${trust_image_tag}" --replace
+                --input "oci:${trust_image_ref}" --replace
             else
+              echo ">>> ${trust_image_ref} does not exist and will be pushed"
               ec --debug track bundle --freshen \
                 --bundle "$(params.BUNDLE_REF)" \
-                --output "oci:${trust_image_repo}:${trust_image_tag}"
+                --output "oci:${trust_image_ref}"
             fi
 
-            echo "Done"
+            echo ">>> Done"

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -538,13 +538,17 @@ spec:
       params:
       - name: BUNDLE_REF
         value: $(tasks.get-bundle-info.results.BUNDLE_REF)
-      - name: TRUST_IMAGE
-        value: $(params.output-trust-data-repo):$(tasks.get-floating-tag.results.FLOATING_TAG)
+      - name: TRUST_IMAGE_REPO
+        value: $(params.output-trust-data-repo)
+      - name: TRUST_IMAGE_TAG
+        value: $(tasks.get-floating-tag.results.FLOATING_TAG)
       taskSpec:
         params:
         - name: BUNDLE_REF
           type: string
-        - name: TRUST_IMAGE
+        - name: TRUST_IMAGE_REPO
+          type: string
+        - name: TRUST_IMAGE_TAG
           type: string
         steps:
         - name: update-tasks-trust
@@ -553,8 +557,42 @@ spec:
             #!/usr/bin/env bash
             set -euo pipefail
 
-            ec --debug track bundle --freshen \
-              --bundle "$(params.BUNDLE_REF)" \
-              --input "oci:$(params.TRUST_IMAGE)" --replace
+            trust_image_tag="$(params.TRUST_IMAGE_TAG)"
+            trust_image_repo="$(params.TRUST_IMAGE_REPO)"
+            trust_image_repo_no_quay_io="${trust_image_repo#quay.io}"
+
+            trust_image_remote_tag_name="$( curl --silent --show-error --fail --location \
+                --get --data-urlencode "specificTag=${trust_image_tag}" \
+                "https://quay.io/api/v1/repository/${trust_image_repo_no_quay_io}/tag/" | \
+              jq -r ".tags[0].name" )"
+
+            # The `ec track bundle` command isn't designed in a friendly way for us, unfortunately.
+            #
+            # Its `--input` argument (combined with `--replace`) is what we need most of times. Despite its name, it not
+            # only loads existing trust info from the provided location, it also pushes the updated info to that same
+            # location. When we use `--input`, the trust data accumulates (which is what we need).
+            # However, the command with `--input` fails when the tag we want to push to doesn't exist. If it did not
+            # fail but push an image in this case, that would be the only necessary command.
+            # The error looks like this:
+            #  Error: GET https://quay.io/v2/rhacs-eng/konflux-tasks-trust/manifests/pr-7: MANIFEST_UNKNOWN: manifest unknown; map[]
+            #
+            # There is the `--output` argument which unlike `--input` does not fail when the image does not exist but
+            # creates it. The issue with `--output` is that it overwrites any existing trust data with just one bundle.
+            # Therefore, `--output` should only be used when the trust image does not yet exist.
+            #
+            # The logic here is to check whether the trust image already exists under the specified floating tag and
+            # use `--input` when it does, otherwise use `--output`. Unfortunately, this is check-then-act and prone to
+            # races but hopefully races between the first pipeline runs aren't common and issues shouldn't appear after
+            # that.
+            #
+            if [[ "${trust_image_remote_tag_name}" != "null" ]]; then
+              ec --debug track bundle --freshen \
+                --bundle "$(params.BUNDLE_REF)" \
+                --input "oci:${trust_image_repo}:${trust_image_tag}" --replace
+            else
+              ec --debug track bundle --freshen \
+                --bundle "$(params.BUNDLE_REF)" \
+                --output "oci:${trust_image_repo}:${trust_image_tag}"
+            fi
 
             echo "Done"

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -565,6 +565,7 @@ spec:
             trust_image_ref="${trust_image_repo}:${trust_image_tag}"
 
             trust_image_remote_tag_name="$( curl --silent --show-error --fail --location \
+                --retry 5 --retry-all-errors --max-time 60 \
                 --get --data-urlencode "specificTag=${trust_image_tag}" \
                 "https://quay.io/api/v1/repository/${trust_image_repo_no_quay_io}/tag/" | \
               jq -r ".tags[0].name" )"

--- a/tasks/determine-image-tag-stackrox-task.yaml
+++ b/tasks/determine-image-tag-stackrox-task.yaml
@@ -34,7 +34,7 @@ spec:
       name: workdir
   steps:
   - name: use-trusted-artifact
-    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:81c4864dae6bb11595f657be887e205262e70086a05ed16ada827fd6391926ac
+    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
     args:
     - use
     - $(params.SOURCE_ARTIFACT)=/var/workdir/source

--- a/tasks/determine-image-tag-task.yaml
+++ b/tasks/determine-image-tag-task.yaml
@@ -26,7 +26,7 @@ spec:
       name: workdir
   steps:
   - name: use-trusted-artifact
-    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:52f1391e6f1c472fd10bb838f64fae2ed3320c636f536014978a5ddbdfc6b3af
+    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
     args:
     - use
     - $(params.SOURCE_ARTIFACT)=/var/workdir/source

--- a/tasks/fetch-external-networks-task.yaml
+++ b/tasks/fetch-external-networks-task.yaml
@@ -32,7 +32,7 @@ spec:
       name: workdir
   steps:
   - name: use-trusted-artifact
-    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:81c4864dae6bb11595f657be887e205262e70086a05ed16ada827fd6391926ac
+    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
     args:
     - use
     - $(params.SOURCE_ARTIFACT)=/var/workdir/source
@@ -45,7 +45,7 @@ spec:
       microdnf -y install zip
       image/rhel/fetch-stackrox-data.sh "$(params.TARGET_DIR)"
   - name: create-trusted-artifact
-    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:81c4864dae6bb11595f657be887e205262e70086a05ed16ada827fd6391926ac
+    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
     args:
     - create
     - --store

--- a/tasks/fetch-scanner-v2-data-task.yaml
+++ b/tasks/fetch-scanner-v2-data-task.yaml
@@ -39,7 +39,7 @@ spec:
       name: workdir
   steps:
   - name: use-trusted-artifact
-    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:52f1391e6f1c472fd10bb838f64fae2ed3320c636f536014978a5ddbdfc6b3af
+    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
     args:
     - use
     - $(params.SOURCE_ARTIFACT)=/var/workdir/source
@@ -60,7 +60,7 @@ spec:
     # If the task times out, look there to debug.
     timeout: 1h30m
   - name: create-trusted-artifact
-    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:52f1391e6f1c472fd10bb838f64fae2ed3320c636f536014978a5ddbdfc6b3af
+    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
     args:
     - create
     - --store

--- a/tasks/fetch-scanner-v4-vuln-mappings-task.yaml
+++ b/tasks/fetch-scanner-v4-vuln-mappings-task.yaml
@@ -32,7 +32,7 @@ spec:
       name: workdir
   steps:
   - name: use-trusted-artifact
-    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:81c4864dae6bb11595f657be887e205262e70086a05ed16ada827fd6391926ac
+    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
     args:
     - use
     - $(params.SOURCE_ARTIFACT)=/var/workdir/source
@@ -41,7 +41,7 @@ spec:
     workingDir: /var/workdir/source
     script: scanner/image/scanner/download-mappings.sh "$(params.TARGET_DIR)"
   - name: create-trusted-artifact
-    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:81c4864dae6bb11595f657be887e205262e70086a05ed16ada827fd6391926ac
+    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
     args:
     - create
     - --store

--- a/tasks/retag-image-task.yaml
+++ b/tasks/retag-image-task.yaml
@@ -34,7 +34,7 @@ spec:
     description: Image reference of the output image containing both the repository, the tag and the digest.
   steps:
   - name: retag-image
-    image: quay.io/konflux-ci/release-service-utils:latest@sha256:5631aada144d09e049bdc47fb25bf38ebc855c20e5535527a7c41a20befcd0d0
+    image: quay.io/konflux-ci/release-service-utils:latest@sha256:7acbc2090819cc416c9e34a16cb108efd3015aaad4ec292ebc691296244af56c
     script: |
       #!/usr/bin/env bash
       set -euo pipefail


### PR DESCRIPTION
`update-tasks-trust` failed in master push of https://github.com/stackrox/konflux-tasks/pull/3 (see https://github.com/stackrox/konflux-tasks/commit/5c84623d4d66726551c3ef71357924d131315ea3 / https://github.com/stackrox/konflux-tasks/runs/34534649551).

```
time="2024-12-17T13:16:36Z" level=debug msg="globalTimeout is 300000000000" func=func1 file=" root_cmd.go:80"
Error: GET https://quay.io/v2/rhacs-eng/konflux-tasks-trust/manifests/latest: MANIFEST_UNKNOWN: manifest unknown; map[]
```

That's because it was the first attempt to push to `latest` tag which did not exist yet.

The same did not happen in my PR https://github.com/stackrox/konflux-tasks/pull/3 because when experimenting with `ec track bundle` I first used `--output` argument and got `pr-3` tag allocated this way.

This change should fix the problem.

### Testing

1. CI here updates on the existing tag.
![image](https://github.com/user-attachments/assets/c2f85b62-08ce-40fe-90e8-bbbea71a73cd)

2. CI in a new branch pushed a new tag. https://github.com/stackrox/konflux-tasks/pull/8
![image](https://github.com/user-attachments/assets/8ab92d6f-3c04-4388-a405-2f607ecd9f3d)
