### PR TITLE
ROX-27352: Setup Renovate config for our tasks

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,47 @@
+{
+  // This configures Konflux Renovate bot, the thing that keeps our pipelines use up-to-date tasks.
+
+  // After making changes to this file, you can validate it by running something like this in the root of the repo:
+  // $ docker run --rm -it --entrypoint=renovate-config-validator -v "$(pwd)":/mnt -w /mnt renovate/renovate --strict
+  // There are more validation options, see https://docs.renovatebot.com/config-validation/
+
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    // This inherits the base Konflux config.
+    // Clickable link https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json
+    // The following was used as example (we may want to check it if the base config gets suddenly moved):
+    // https://github.com/enterprise-contract/ec-cli/blob/407847910ad420850385eea1db78e2a2e49c7e25/renovate.json#L1C1-L7C2
+    "github>konflux-ci/mintmaker//config/renovate/renovate.json",
+    // This tells Renovate to combine all updates in one PR so that we have less PRs to deal with.
+    "group:all",
+  ],
+  "timezone": "Etc/UTC",
+  "schedule": [
+    // Allowed syntax: https://docs.renovatebot.com/configuration-options/#schedule
+    // The time was selected (with the help of https://time.fyi/timezones) so that Renovate isn't active during business
+    // hours from Germany to US West Coast. This way, after we merge a PR, a new one does not pop up immediately after
+    // that.
+    "after 3am and before 7am",
+  ],
+  // Tell Renovate not to update PRs when outside of schedule.
+  "updateNotScheduled": false,
+  "tekton": {
+    "schedule": [
+      // For some reason, Konflux config defines custom schedule on each type of dependency manager and that takes
+      // precedence over the global/default schedule. We want our own schedule and hence need to make this override.
+      "after 3am and before 7am",
+    ],
+  },
+  "dockerfile": {
+    "includePaths": [
+      // Instruct Renovate not try to update Dockerfiles other than konflux.Dockerfile (or konflux.anything.Dockerfile)
+      // to have less PR noise.
+      "**/*konflux*.Dockerfile",
+    ],
+  },
+  "enabledManagers": [
+    // Restrict Renovate focus on Konflux things since we rely on GitHub's dependabot for everything else.
+    "tekton",
+    "dockerfile",
+  ],
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,6 @@
 {
-  // This configures Konflux Renovate bot, the thing that keeps our pipelines use up-to-date tasks.
+  // This configures Konflux Renovate bot, the thing that keeps our pipelines use up-to-date tasks and tasks use
+  // up-to-date images.
 
   // After making changes to this file, you can validate it by running something like this in the root of the repo:
   // $ docker run --rm -it --entrypoint=renovate-config-validator -v "$(pwd)":/mnt -w /mnt renovate/renovate --strict

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,6 +27,10 @@
   // Tell Renovate not to update PRs when outside of schedule.
   "updateNotScheduled": false,
   "tekton": {
+    "includePaths": [
+      ".tekton/**",
+      "tasks/**",
+    ],
     "schedule": [
       // For some reason, Konflux config defines custom schedule on each type of dependency manager and that takes
       // precedence over the global/default schedule. We want our own schedule and hence need to make this override.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,7 +21,8 @@
     // The time was selected (with the help of https://time.fyi/timezones) so that Renovate isn't active during business
     // hours from Germany to US West Coast. This way, after we merge a PR, a new one does not pop up immediately after
     // that.
-    "after 3am and before 7am",
+    // TODO(ROX-27352): "after 3am and before 7am",
+    "at any time",
   ],
   // Tell Renovate not to update PRs when outside of schedule.
   "updateNotScheduled": false,
@@ -29,7 +30,8 @@
     "schedule": [
       // For some reason, Konflux config defines custom schedule on each type of dependency manager and that takes
       // precedence over the global/default schedule. We want our own schedule and hence need to make this override.
-      "after 3am and before 7am",
+      // TODO(ROX-27352): "after 3am and before 7am",
+      "at any time",
     ],
   },
   "enabledManagers": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,16 +32,7 @@
       "after 3am and before 7am",
     ],
   },
-  "dockerfile": {
-    "includePaths": [
-      // Instruct Renovate not try to update Dockerfiles other than konflux.Dockerfile (or konflux.anything.Dockerfile)
-      // to have less PR noise.
-      "**/*konflux*.Dockerfile",
-    ],
-  },
   "enabledManagers": [
-    // Restrict Renovate focus on Konflux things since we rely on GitHub's dependabot for everything else.
     "tekton",
-    "dockerfile",
   ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -37,6 +37,9 @@
       // TODO(ROX-27352): "after 3am and before 7am",
       "at any time",
     ],
+    "automerge": true,
+    "automergeType": "pr",
+    "automergeStrategy": "squash",
   },
   "enabledManagers": [
     "tekton",


### PR DESCRIPTION
I suggest reviewing this change by commits, I broke down changes and assisted them with commit messages.

### Testing

Ran config validator, it was ok.