### PR TITLE
doc: Mention Quay repos in top-level readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Tasks themselves are in `tasks/` directory.
 
 `.tekton/` directory has the pipeline to package and push tasks as Tekton bundle OCI image for use in pipelines.
 
+Tasks are pushed to [quay.io/rhacs-eng/konflux-tasks](https://quay.io/repository/rhacs-eng/konflux-tasks) repo.  
+Tasks trust data for inclusion in EC policy is pushed to [quay.io/rhacs-eng/konflux-tasks-trust](https://quay.io/repository/rhacs-eng/konflux-tasks-trust).
+
 ## Development
 
 For as long as there are no automated tests ([ROX-27386](https://issues.redhat.com/browse/ROX-27386) is to add them), you should open PRs in consuming repos when changing tasks in order to validate your changes.


### PR DESCRIPTION
So that the information is on the surface without the need to dig into the pipeline code.

Readme preview: https://github.com/stackrox/konflux-tasks/blob/misha/mention-quay-repos-in-readme/README.md