### PR TITLE
ROX-27352: Try enable Renovate automerge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,7 +39,7 @@
       "at any time",
     ],
     "automerge": true,
-    "automergeType": "pr",
+    "automergeType": "branch",
     "automergeStrategy": "squash",
   },
   "enabledManagers": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,6 +39,8 @@
       "at any time",
     ],
     "automerge": true,
+    // PRs can't be actually automerged because we require approval from CODEOWNERS which Renovate can't bypass,
+    // therefore we set automerge type to branch.
     "automergeType": "branch",
     "automergeStrategy": "squash",
   },

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -7,8 +7,10 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
+    # The on-push filter includes konflux/* branches which are created by Mintmaker so that CI runs for commits pushed
+    # onto these branches even without PRs and so that Mintmaker/Renovate can automerge its updates without PRs.
     pipelinesascode.tekton.dev/on-cel-expression: |
-      (event == "push" && target_branch == "main") ||
+      (event == "push" && target_branch.matches("^(master|konflux/references/main|konflux/mintmaker/.*)$")) ||
       (event == "pull_request")
   creationTimestamp: null
   labels:


### PR DESCRIPTION
### Description

After I first set up Renovate config in https://github.com/stackrox/konflux-tasks/pull/11, renovate automerging did not start happening which I saw in https://github.com/stackrox/konflux-tasks/pull/4 and https://github.com/stackrox/konflux-tasks/pull/17 after those PRs got rebased.

The root cause is that we require an approval from CODEOWNERS in order to merge a PR. Apparently, there's no way Renovate can bypass that.

See <https://docs.renovatebot.com/key-concepts/automerge/#codeowners>:
> Depending on the platform, having a `CODEOWNERS` file could block automerging, because it means a code owner must review the PR.

In my searches of GitHub issues, I did not find a way around it.

Also, https://github.com/apps/renovate-approve says it's not usable for this problem:
> Important note: Due to a GitHub limitation, it is not possible to assign any app like this one as a CODEOWNER, so unfortunately this bot won't work that way if you have CODEOWNERS set up.

I tried following [this advice](https://www.github.com/orgs/community/discussions/46626#discussioncomment-5731948) by creating two separate rulesets. What I could achieve that way is this wonderful checkbox to appear
![image](https://github.com/user-attachments/assets/cf8c39cd-2a4c-46d8-be02-7ae2db1e1aed)
Renovate does not know how to set this checkbox (the thing looks very github specific) and so it won't automerge the PR that way.

The solution I propose is to move away from opening PRs and let Renovate just create branches for its changes.
The branch automerging description ([here](https://docs.renovatebot.com/key-concepts/automerge/#branch-vs-pr-automerging) and [here](https://docs.renovatebot.com/configuration-options/#automergetype)) reads reasonably safe to me so I'm optimistic about enabling it.

I already tweaked rulesets in a way that I think should work fine with this change:
1. This sets basic protection for `main` which includes everything except of PR requirements - <https://github.com/stackrox/konflux-tasks/settings/rules/2938374>. It has no bypass.
2. This sets PR requirements for `main`, same as we [configured earlier](https://redhat-internal.slack.com/archives/C081BAM590Q/p1734630170401979) - <https://github.com/stackrox/konflux-tasks/settings/rules/3137751>. It can be bypassed by `Red Hat Konflux` App. Meaning that Renovate/Mintmaker (which operates under this app) would be exempt from opening PRs and consequently CODEOWNERS approvals if it wants to update `main`.

Note that Renovate needs CI status to be reported in order to decide to merge. That's why I tweaked pipeline's CEL expression based on branch names that I saw in Renovate PRs.

### Testing

None (apart from config validation).
I don't know how the thing is going to work. The only way to figure it out would be to merge this PR and observe what happens after.