### PR TITLE
ROX-27352: Set automerge schedule to create branches at quiet time

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,8 +22,7 @@
     // The time was selected (with the help of https://time.fyi/timezones) so that Renovate isn't active during business
     // hours from Germany to US West Coast. This way, after we merge a PR, a new one does not pop up immediately after
     // that.
-    // TODO(ROX-27352): "after 3am and before 7am",
-    "at any time",
+    "after 3am and before 7am",
   ],
   // Tell Renovate not to update PRs when outside of schedule.
   "updateNotScheduled": false,
@@ -35,8 +34,7 @@
     "schedule": [
       // For some reason, Konflux config defines custom schedule on each type of dependency manager and that takes
       // precedence over the global/default schedule. We want our own schedule and hence need to make this override.
-      // TODO(ROX-27352): "after 3am and before 7am",
-      "at any time",
+      "after 3am and before 7am",
     ],
     "automerge": true,
     // PRs can't be actually automerged because we require approval from CODEOWNERS which Renovate can't bypass,


### PR DESCRIPTION
### Description

Renovate automerging started happening after https://github.com/stackrox/konflux-tasks/pull/18.
I thought we need to additionally configure StackRox, Collector and Scanner repos to update our `quay.io/rhacs-eng/konflux-tasks` image but this seems to be happening without any extra config. Yay!
See https://github.com/stackrox/stackrox/pull/13493 and https://github.com/stackrox/collector/pull/2003.

What remains in the scope of https://issues.redhat.com/browse/ROX-27352 is to calm down Renovate to not send changes during our working hours.

In this change I simply restore the same `after 3am and before 7am` expression we use in other repos. I don't know yet whether it would be too frequent or ok.
Note that this schedule configures the time when Renovate will create new branches or refresh existing ones. In order to additionally limit the time when Renovate _merges_ them, we could use the [automergeSchedule](https://docs.renovatebot.com/configuration-options/#automergeschedule) setting. At this point, I don't see a case for us to limit that assuming that the pipeline should execute quickly enough. I suggest that we leave it out for now but have in mind for the future.

There's an obvious downside of having Renovate making and merging changes automatically - potential merge conflicts if an engineer makes a change to the step `image` or to tasks in the build pipeline in their PR. This is unavoidable and the only way to limit the impact is by reducing the frequency through the schedule. Again, let's start with this schedule and see if the conflicts become bothering, then we can reduce it.

### Testing

None. Just ran a validator.
Will observe Renovate commits for a few days after this change gets merged.