### PR TITLE
build: Fix image tag for renovate branches

### DIFF
--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -459,8 +459,8 @@ spec:
             if [[ "${EVENT_TYPE}" == "pull_request" ]]; then
               floating_tag="pr-${PULL_REQUEST_NUMBER}"
             else
-              floating_tag="${SOURCE_BRANCH}"
-              if [[ "${floating_tag}" == "main" ]]; then
+              floating_tag="$(echo "${SOURCE_BRANCH}" | sed 's/[^a-zA-Z0-9_.]/-/g')"
+              if [[ "${SOURCE_BRANCH}" == "main" ]]; then
                 floating_tag="latest"
               fi
             fi

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -444,7 +444,7 @@ spec:
           description: Floating tag to apply to the resulting images.
         steps:
         - name: get-floating-tag
-          image: registry.redhat.io/ubi9-micro:latest@sha256:f6e0a71b7e0875b54ea559c2e0a6478703268a8d4b8bdcf5d911d0dae76aef51
+          image: registry.redhat.io/ubi9-minimal:latest@sha256:b87097994ed62fbf1de70bc75debe8dacf3ea6e00dd577d74503ef66452c59d6
           env:
           - name: EVENT_TYPE
             value: '{{event_type}}'


### PR DESCRIPTION
In https://console.redhat.com/application-pipeline/workspaces/rh-acs/applications/acs-konflux-tasks/pipelineruns/acs-konflux-tasks-on-push-tzqlj I noticed `apply-tags` fails with:
> `step-apply-additional-tags-from-parameter
Applying tag konflux/mintmaker/all
time="2025-01-13T11:41:44Z" level=fatal msg="Invalid destination name docker://quay.io/rhacs-eng/konflux-tasks:konflux/mintmaker/all: invalid reference format"`

That was not a PR-triggered pipeline, but a push-triggered to `konflux/mintmaker/all` branch. I.e. renovate on-push CI.
The tag is invalid because `/` characters aren't allowed there.

I this PR I convert all non-accepted characters to dashes. The allowed characters are mentioned in https://docs.docker.com/reference/cli/docker/image/tag/

I don't put a length limit because let's first see the branch name with more than 128 characters.

### Testing

CI on a manually created `konflux/mintmaker/misha-test-pr-25` branch https://console.redhat.com/application-pipeline/workspaces/rh-acs/applications/acs-konflux-tasks/pipelineruns/acs-konflux-tasks-on-push-5gtrb does not fail and uses `konflux-mintmaker-misha-test-pr-25` as tag.