### PR TITLE
ROX-22250: Sanitize tags: `<N>.<M>.x` to `<N>.<M>.0`

### DIFF
--- a/tasks/determine-image-tag-task.yaml
+++ b/tasks/determine-image-tag-task.yaml
@@ -91,6 +91,16 @@ spec:
         tag_from_makefile="$(make -C "$(params.MAKEFILE_DIRECTORY)" --quiet --no-print-directory tag)"
         log "Tag reported by Makefile: '${tag_from_makefile}'"
 
+        # Fast stream tags/versions must be comparable according to SemVer and so versions like '4.7.x-anything' should
+        # be converted to '4.7.0-anything'.
+        local tag_from_makefile_sanitized
+        tag_from_makefile_sanitized="$(echo "${tag_from_makefile}" | sed -E 's@^(([[:digit:]]+\.)+)x(-)?@\10\3@g' )"
+        log "Tag from Makefile with '.x' sanitized: '${tag_from_makefile_sanitized}'"
+
+        local stackrox_repo
+        stackrox_repo="$(is_stackrox_repo)"
+        log "Is this StackRox repo: ${stackrox_repo}"
+
         local tags_from_git
         tags_from_git="$(git tag --points-at)"
         local -a tags_from_git_arr
@@ -119,9 +129,24 @@ spec:
           return
         fi
 
+        if [[ "${stackrox_repo}" == "yes" ]]; then
+          log "Using sanitized Makefile output ${tag_from_makefile_sanitized} for the tag."
+          echo "${tag_from_makefile_sanitized}"
+          return
+        fi
+
         log "Using Makefile output ${tag_from_makefile} for the tag."
         echo "${tag_from_makefile}"
         return
+      }
+
+      # A poor-man's way to differentiate stackrox/stackrox repo from stackrox/collector, stackrox/scanner and others.
+      function is_stackrox_repo() {
+        result="no"
+        if git remote -v | grep -qE '(\b)stackrox/stackrox(\b)'; then
+          result="yes"
+        fi
+        echo "${result}"
       }
 
       main

--- a/tasks/determine-image-tag-task.yaml
+++ b/tasks/determine-image-tag-task.yaml
@@ -91,7 +91,7 @@ spec:
         tag_from_makefile="$(make -C "$(params.MAKEFILE_DIRECTORY)" --quiet --no-print-directory tag)"
         log "Tag reported by Makefile: '${tag_from_makefile}'"
 
-        # Fast stream tags/versions must be comparable according to SemVer and so versions like '4.7.x-anything' should
+        # Fast Stream tags/versions must be comparable according to SemVer and so versions like '4.7.x-anything' should
         # be converted to '4.7.0-anything'.
         local tag_from_makefile_sanitized
         tag_from_makefile_sanitized="$(echo "${tag_from_makefile}" | sed -E 's@^(([[:digit:]]+\.)+)x(-)?@\10\3@g' )"
@@ -129,6 +129,12 @@ spec:
           return
         fi
 
+        # We sanitize StackRox tags for Fast Stream users so that versions are comparable according to SemVer.
+        # We must not sanitize tags for Collector and Scanner because these are internal, development tags (e.g.
+        # 3.20.x-80-g5afdaf059a and 2.35.x-57-ga9da3070bd) which are not exposed to users (and they must match the
+        # contents of COLLECTOR_VERSION and SCANNER_VERSION files); instead we add unified tags (same as on images built
+        # from StackRox repo, e.g. 4.7.0-551-g1ca8d0d66e-fast) to user-facing Collector and Scanner images (with
+        # retagging and/or release pipelines).
         if [[ "${stackrox_repo}" == "yes" ]]; then
           log "Using sanitized Makefile output ${tag_from_makefile_sanitized} for the tag."
           echo "${tag_from_makefile_sanitized}"


### PR DESCRIPTION
### Description

Per description.

This isn't needed for Stable Stream, only for Fast Stream but I thought it's easier to do now when the context is fresh for me than to come back to this later.

For reviewer(s): please see my comment (below) and share your preferences.

### Testing

- https://github.com/stackrox/stackrox/pull/13995
- https://github.com/stackrox/scanner/pull/1788
- https://github.com/stackrox/collector/pull/2021