### PR TITLE
chore: Set fixed memory requests==limits for TA tasks

### DIFF
--- a/tasks/determine-dependency-image-tag-task.yaml
+++ b/tasks/determine-dependency-image-tag-task.yaml
@@ -33,6 +33,11 @@ spec:
   steps:
   - name: use-trusted-artifact
     image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+    computeResources:
+      requests:
+        memory: 2Gi
+      limits:
+        memory: 2Gi
     args:
     - use
     - $(params.SOURCE_ARTIFACT)=/var/workdir/source

--- a/tasks/determine-image-tag-task.yaml
+++ b/tasks/determine-image-tag-task.yaml
@@ -34,6 +34,11 @@ spec:
   steps:
   - name: use-trusted-artifact
     image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+    computeResources:
+      requests:
+        memory: 2Gi
+      limits:
+        memory: 2Gi
     args:
     - use
     - $(params.SOURCE_ARTIFACT)=/var/workdir/source

--- a/tasks/fetch-external-networks-task.yaml
+++ b/tasks/fetch-external-networks-task.yaml
@@ -33,6 +33,11 @@ spec:
   steps:
   - name: use-trusted-artifact
     image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+    computeResources:
+      requests:
+        memory: 2Gi
+      limits:
+        memory: 2Gi
     args:
     - use
     - $(params.SOURCE_ARTIFACT)=/var/workdir/source
@@ -46,6 +51,11 @@ spec:
       image/rhel/fetch-stackrox-data.sh "$(params.TARGET_DIR)"
   - name: create-trusted-artifact
     image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+    computeResources:
+      requests:
+        memory: 2Gi
+      limits:
+        memory: 2Gi
     args:
     - create
     - --store

--- a/tasks/fetch-scanner-v2-data-task.yaml
+++ b/tasks/fetch-scanner-v2-data-task.yaml
@@ -48,6 +48,11 @@ spec:
 
   - name: use-trusted-artifact
     image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+    computeResources:
+      requests:
+        memory: 2Gi
+      limits:
+        memory: 2Gi
     args:
     - use
     - $(params.SOURCE_ARTIFACT)=/var/workdir/source
@@ -117,6 +122,11 @@ spec:
 
   - name: create-trusted-artifact
     image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+    computeResources:
+      requests:
+        memory: 2Gi
+      limits:
+        memory: 2Gi
     args:
     - create
     - --store

--- a/tasks/fetch-scanner-v4-vuln-mappings-task.yaml
+++ b/tasks/fetch-scanner-v4-vuln-mappings-task.yaml
@@ -33,6 +33,11 @@ spec:
   steps:
   - name: use-trusted-artifact
     image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+    computeResources:
+      requests:
+        memory: 2Gi
+      limits:
+        memory: 2Gi
     args:
     - use
     - $(params.SOURCE_ARTIFACT)=/var/workdir/source
@@ -42,6 +47,11 @@ spec:
     script: scanner/image/scanner/download-mappings.sh "$(params.TARGET_DIR)"
   - name: create-trusted-artifact
     image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+    computeResources:
+      requests:
+        memory: 2Gi
+      limits:
+        memory: 2Gi
     args:
     - create
     - --store


### PR DESCRIPTION
There's an ongoing problem around trusted artifacts step failures https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1738140793949009

When looking at one such failing pod, I noticed
```
    Limits:
      memory:  2Gi
    Requests:
      cpu:     50m
      memory:  128Mi
```

I suspect the failures may be related to memory pressure on the nodes, it will help to set requests same as limits. It also makes it simpler to reason about oom kills when requests are the same as limits because we know that kills happen at the predictable boundary.

As a precedent, we had to bump resources in Collector builds before. https://github.com/stackrox/collector/pull/1913

This will not help with failures in tasks we don't own. For that we can only create overrides how it's done in Collector https://github.com/stackrox/collector/blob/d6c343486e7a3b8ec40f5395e556ff531b3ff8b8/.tekton/collector-build.yaml#L72-L113 or hope that the Konflux team patches all tasks for us.

### Testing

Basic smoke test in https://github.com/stackrox/scanner/pull/1794