### PR TITLE
chore: update renovate config: more auto-merge, more often

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -45,5 +45,6 @@
   "enabledManagers": [
     "tekton",
   ],
+  labels: ["auto-merge"],
   "platformAutomerge": true
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,18 +13,18 @@
     // The following was used as example (we may want to check it if the base config gets suddenly moved):
     // https://github.com/enterprise-contract/ec-cli/blob/407847910ad420850385eea1db78e2a2e49c7e25/renovate.json#L1C1-L7C2
     "github>konflux-ci/mintmaker//config/renovate/renovate.json",
-    // This tells Renovate to combine all updates in one PR so that we have less PRs to deal with.
+    // This tells Renovate to combine all updates in one PR so that we have fewer PRs to deal with.
     "group:all",
   ],
   "timezone": "Etc/UTC",
   "schedule": [
     // Allowed syntax: https://docs.renovatebot.com/configuration-options/#schedule
-    // The time was selected (with the help of https://time.fyi/timezones) so that Renovate isn't active during business
-    // hours from Germany to US West Coast. This way, after we merge a PR, a new one does not pop up immediately after
-    // that.
-    "after 3am and before 7am",
+    // Open PRs as soon as possible, even if opening a PR right after another one was merged.
+    // Automerging will take care of handling PRs.
+    // New PRs to update the Component pipelines will only be scheduled during their defined schedule.
+    "at any time",
   ],
-  // Tell Renovate not to update PRs when outside of schedule.
+  // Tell Renovate to update PRs even when outside of schedule.
   "updateNotScheduled": false,
   "tekton": {
     "includePaths": [
@@ -34,7 +34,7 @@
     "schedule": [
       // For some reason, Konflux config defines custom schedule on each type of dependency manager and that takes
       // precedence over the global/default schedule. We want our own schedule and hence need to make this override.
-      "after 3am and before 7am",
+      "at any time",
     ],
     "automerge": true,
     // PRs can't be actually automerged because we require approval from CODEOWNERS which Renovate can't bypass,
@@ -45,4 +45,5 @@
   "enabledManagers": [
     "tekton",
   ],
+  "platformAutomerge": true
 }

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,17 @@
+name: auto-merge
+
+on:
+  pull_request_target:
+    types:
+    - labeled
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'red-hat-konflux[bot]' && github.event.label.name == 'auto-merge'
+    env:
+      GH_TOKEN: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
+    steps:
+    - name: Approve PR
+      run: |
+        gh pr review ${{ github.event.pull_request.number }} --approve --body "/ok-to-test" --repo ${{ github.repository }}


### PR DESCRIPTION
- platformautomerge worked better to open and merge PRs in my experiments: https://docs.renovatebot.com/configuration-options/#platformautomerge
- schedule updates always, as reviews can happen automatically. 
- add workflow to auto-approve PRs if they're opened. 