### PR TITLE
ROX-27831: set image expiration based on event type and target branch

### DIFF
--- a/tasks/determine-image-expiration-parameter-task.yaml
+++ b/tasks/determine-image-expiration-parameter-task.yaml
@@ -1,0 +1,41 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: determine-image-expiration-parameter
+spec:
+  description: Determines the image expiration parameter, or sets to empty for release images.
+  params:
+  - name: DEFAULT_IMAGE_EXPIRES_AFTER
+    description: Default image expiration.
+    type: string
+  results:
+  - name: IMAGE_EXPIRES_AFTER
+    description: Image expiration as a duration, e.g. `13w`.
+  steps:
+  - name: determine-image-expiration-parameter
+    image: registry.access.redhat.com/ubi9:latest@sha256:53d6c19d664f4f418ce5c823d3a33dbb562a2550ea249cf07ef10aa063ace38f
+    env:
+    - name: PIPELINE_EVENT_TYPE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.labels['pipelinesascode.tekton.dev/event-type']
+    - name: PIPELINE_TARGET_BRANCH
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.annotations['build.appstudio.redhat.com/target_branch']
+    script: |
+      #!/usr/bin/env bash
+
+      set -euo pipefail
+
+      echo "Default image expiration: $(params.DEFAULT_IMAGE_EXPIRES_AFTER)"
+      echo "Event type: ${PIPELINE_EVENT_TYPE}"
+      echo "Target branch: ${PIPELINE_TARGET_BRANCH}"
+
+      # TODO(ROX-28001): Update the expiration logic for -fast releases.
+      if [[ "${PIPELINE_EVENT_TYPE}" == "push" && "${PIPELINE_TARGET_BRANCH}" == refs/tags/* ]]; then
+        IMAGE_EXPIRES_AFTER=""
+      else
+        IMAGE_EXPIRES_AFTER="$(params.DEFAULT_IMAGE_EXPIRES_AFTER)"
+      fi
+      echo -n "${IMAGE_EXPIRES_AFTER}" | tee "$(results.IMAGE_EXPIRES_AFTER.path)"

--- a/tasks/determine-image-expiration-parameter-task.yaml
+++ b/tasks/determine-image-expiration-parameter-task.yaml
@@ -3,7 +3,7 @@ kind: Task
 metadata:
   name: determine-image-expiration-parameter
 spec:
-  description: Determines the image expiration parameter, or sets to empty for release images.
+  description: Determines the image expiration parameter, or sets to empty for git-tagged builds.
   params:
   - name: DEFAULT_IMAGE_EXPIRES_AFTER
     description: Default image expiration.

--- a/tasks/determine-image-expiration-task.yaml
+++ b/tasks/determine-image-expiration-task.yaml
@@ -33,7 +33,7 @@ spec:
       echo "Target branch: ${PIPELINE_TARGET_BRANCH}"
 
       # TODO(ROX-28001): Update the expiration logic for -fast releases.
-      if [[ "${PIPELINE_EVENT_TYPE}" != "pull_request" && "${PIPELINE_TARGET_BRANCH}" == refs/tags/* && "${PIPELINE_TARGET_BRANCH}" != refs/tags/*-nightly-* ]]; then
+      if [[ "${PIPELINE_EVENT_TYPE}" != "pull_request" && "${PIPELINE_TARGET_BRANCH}" == refs/tags/* && "${PIPELINE_TARGET_BRANCH}" != *-nightly-* ]]; then
         echo "This is a tagged build and not a nightly. The images won't expire. IMAGE_EXPIRES_AFTER will be empty."
         IMAGE_EXPIRES_AFTER=""
       else

--- a/tasks/determine-image-expiration-task.yaml
+++ b/tasks/determine-image-expiration-task.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: determine-image-expiration-parameter
+  name: determine-image-expiration
 spec:
   description: Determines the image expiration parameter, or sets to empty for git-tagged builds.
   params:
@@ -12,7 +12,7 @@ spec:
   - name: IMAGE_EXPIRES_AFTER
     description: Image expiration as a duration, e.g. `13w`.
   steps:
-  - name: determine-image-expiration-parameter
+  - name: determine-image-expiration
     image: registry.access.redhat.com/ubi9:latest@sha256:53d6c19d664f4f418ce5c823d3a33dbb562a2550ea249cf07ef10aa063ace38f
     env:
     - name: PIPELINE_EVENT_TYPE
@@ -33,7 +33,8 @@ spec:
       echo "Target branch: ${PIPELINE_TARGET_BRANCH}"
 
       # TODO(ROX-28001): Update the expiration logic for -fast releases.
-      if [[ "${PIPELINE_EVENT_TYPE}" == "push" && "${PIPELINE_TARGET_BRANCH}" == refs/tags/* ]]; then
+      if [[ "${PIPELINE_EVENT_TYPE}" != "pull_request" && "${PIPELINE_TARGET_BRANCH}" == refs/tags/* && "${PIPELINE_TARGET_BRANCH}" != refs/tags/*-nightly-* ]]; then
+        echo "This is a tagged build and not a nightly. The images won't expire. IMAGE_EXPIRES_AFTER will be empty."
         IMAGE_EXPIRES_AFTER=""
       else
         IMAGE_EXPIRES_AFTER="$(params.DEFAULT_IMAGE_EXPIRES_AFTER)"


### PR DESCRIPTION
Validated with https://github.com/stackrox/scanner/pull/1806


- PR with target branch master: 
  - https://github.com/stackrox/scanner/pull/1806/commits/1326d3cf8d6814a63203cc20c98b0f1aa372884d
  - https://console.redhat.com/application-pipeline/workspaces/rh-acs/applications/acs/pipelineruns/scanner-slim-on-push-l7fk8
  - https://console.redhat.com/application-pipeline/workspaces/rh-acs/applications/acs/taskruns/scanner-slim-on-push-l7fk8-determine-image-expiration/details --> result is set to 13w.
  - `podman inspect quay.io/rhacs-eng/scanner-slim:2.35.x-69-g1326d3cf8d-fast | jq -r '.[].Config.Labels["quay.expires-after"]` -> `13w`
- Pushing a tag:
  - https://github.com/stackrox/scanner/tree/0.0.0-tm-test.1
  - https://console.redhat.com/application-pipeline/workspaces/rh-acs/applications/acs/pipelineruns/scanner-db-slim-on-push-jm9lc
  - https://console.redhat.com/application-pipeline/workspaces/rh-acs/applications/acs/taskruns/scanner-db-slim-on-push-jm9lc-determine-image-expiration/details --> result is empty as expected.
  - `podman inspect quay.io/rhacs-eng/scanner-db-slim:0.0.0-tm-test.1-fast | jq -r '.[].Config.Labels["quay.expires-after"]'` -> `null`
  - normal EC is green: https://console.redhat.com/application-pipeline/workspaces/rh-acs/applications/acs/pipelineruns/acs-enterprise-contract-lk2bg/logs (well, not green, but no mention of missing labels or image expiration)