### PR TITLE
ROX-27901: Tweak Renovate's branch automerge schedule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,14 +18,14 @@
   ],
   "timezone": "Etc/UTC",
   "schedule": [
+    // This controls when Renovate can create new branches and open PRs.
     // Allowed syntax: https://docs.renovatebot.com/configuration-options/#schedule
     // The time was selected (with the help of https://time.fyi/timezones) so that Renovate isn't active during business
-    // hours from Germany to US West Coast. This way, after we merge a PR, a new one does not pop up immediately after
-    // that.
+    // hours from Germany to US West Coast. This way, we limit the number of changes Renovate can merge to one per day.
     "after 3am and before 7am",
   ],
-  // Tell Renovate not to update PRs when outside of schedule.
-  "updateNotScheduled": false,
+  // Tell Renovate that it can rebase and update its branches (and/or its PRs) at times outside the `schedule`.
+  "updateNotScheduled": true,
   "tekton": {
     "includePaths": [
       ".tekton/**",
@@ -41,6 +41,10 @@
     // therefore we set automerge type to branch.
     "automergeType": "branch",
     "automergeStrategy": "squash",
+    // Tell Renovate that it can automerge branches at any time of the day.
+    "automergeSchedule": [
+      "at any time"
+    ],
   },
   "enabledManagers": [
     "tekton",


### PR DESCRIPTION
I noticed that Renovate branches ([konflux/mintmaker/all](https://github.com/stackrox/konflux-tasks/commits/konflux/mintmaker/all) and [konflux/references/main](https://github.com/stackrox/konflux-tasks/commits/konflux/references/main)) can sit there with changes for multiple hours and days without getting merged.

Here I suggest slight tweaks to try and see if Renovate will become more active.
As compared to <https://github.com/stackrox/konflux-tasks/pull/36>:
- I suggest to keep `schedule` because I saw how in other repos Renovate could open a PR right after I merged one and that was annoying. Keeping the current `schedule` we have at most one change initiated per day.
- I keep the `branch` automerge strategy, i.e. without PRs (until/unless there are CI failures) and without auto-approvals, at this point.

Note that I introduce explicit `automergeSchedule` `at any time` even though it should be a default value. I think, it helps a bit make the intent clear.

Renovate docs: https://docs.renovatebot.com/configuration-options/

### Testing

Only ran a validator. Will observe how things go after the merge.