### PR TITLE
ROX-27856: Improve BigQuery metrics task

### DIFF
--- a/tasks/post-bigquery-metrics-task.yaml
+++ b/tasks/post-bigquery-metrics-task.yaml
@@ -52,6 +52,11 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.labels['tekton.dev/pipelineRun']
+    - name: PIPELINE_RUN_UID
+      # E.g. "d9ba34da-d51a-4104-9c40-c9d537d76ef0"
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.labels['tekton.dev/pipelineRunUID']
     - name: ORIGINAL_PIPELINE_RUN_NAME
       # E.g. "scanner-v4-db-on-push"
       valueFrom:
@@ -90,6 +95,10 @@ spec:
 
       AGGREGATE_TASKS_STATUS="$(params.AGGREGATE_TASKS_STATUS)"
 
+      # Even though PIPELINE_RUN_NAME looks unique, it's not guaranteed to be so. There's a chance the same entropy
+      # suffix will be generated over a long period of time. Since we don't want metrics to clash, we append UUID.
+      ID="${PIPELINE_RUN_NAME}.${PIPELINE_RUN_UID}"
+
       successes=0
       errors=0
 
@@ -105,7 +114,7 @@ spec:
         if bq query \
             --headless \
             --use_legacy_sql=false \
-            --parameter="id::${PIPELINE_RUN_NAME}" \
+            --parameter="id::${ID}" \
             --parameter="name::${ORIGINAL_PIPELINE_RUN_NAME}" \
             --parameter="repo::${REPO_URL}" \
             --parameter="branch::${SOURCE_BRANCH}" \

--- a/tasks/post-bigquery-metrics-task.yaml
+++ b/tasks/post-bigquery-metrics-task.yaml
@@ -103,6 +103,7 @@ spec:
         fi
 
         if bq query \
+            --headless \
             --use_legacy_sql=false \
             --parameter="id::${PIPELINE_RUN_NAME}" \
             --parameter="name::${ORIGINAL_PIPELINE_RUN_NAME}" \

--- a/tasks/post-bigquery-metrics-task.yaml
+++ b/tasks/post-bigquery-metrics-task.yaml
@@ -105,8 +105,7 @@ spec:
           sleep "${delay}"
         fi
 
-        # todo: un-negate
-        if ! bq query \
+        if bq query \
             --headless \
             --use_legacy_sql=false \
             --parameter="id::${ID}" \

--- a/tasks/post-bigquery-metrics-task.yaml
+++ b/tasks/post-bigquery-metrics-task.yaml
@@ -27,6 +27,12 @@ spec:
       When this task is at the beginning of the pipeline, don't pass anything.
       When the task is placed in the pipeline's finally block, pass here `$(tasks.status)`.
       Ref https://tekton.dev/docs/pipelines/pipelines/#using-aggregate-execution-status-of-all-tasks
+  results:
+  - name: TEST_OUTPUT
+    description: |
+      Indicates in a way that should not fail the overall pipeline whether metric posting succeeded.
+      The format is according to Konflux convention, see
+      https://konflux-ci.dev/architecture/ADR/0030-tekton-results-naming-convention.html
   volumes:
   - name: gcp-service-account
     secret:
@@ -84,43 +90,80 @@ spec:
 
       AGGREGATE_TASKS_STATUS="$(params.AGGREGATE_TASKS_STATUS)"
 
-      bq query \
-        --use_legacy_sql=false \
-        --parameter="id::${PIPELINE_RUN_NAME}" \
-        --parameter="name::${ORIGINAL_PIPELINE_RUN_NAME}" \
-        --parameter="repo::${REPO_URL}" \
-        --parameter="branch::${SOURCE_BRANCH}" \
-        --parameter="pr_number:INTEGER:${PULL_REQUEST_NUMBER:-NULL}" \
-        --parameter="commit_sha::${COMMIT_SHA}" \
-        --parameter="outcome::${AGGREGATE_TASKS_STATUS:-NULL}" \
-        "
-        -- Create a temporary table for holding a record for this job with the same schema as the target table.
-        CREATE TEMP TABLE _SESSION.this_job AS SELECT * FROM ${TABLE_NAME} LIMIT 0;
+      successes=0
+      errors=0
 
-        -- Add the job's record into the temporary table.
-        INSERT INTO _SESSION.this_job
-          (id, name, repo, branch, pr_number, commit_sha, started_at, outcome, ci_system)
-          VALUES
-          (@id, @name, @repo, @branch, @pr_number, @commit_sha, CURRENT_TIMESTAMP(), @outcome, 'konflux');
+      while (( errors < 3 )); do
+        if (( errors > 0 )); then
+          # Sleep for ~3 minutes. One minute is enough for the task to complete in normal conditions and so hopefully
+          # this sleep should be sufficient for error conditions like full requests queue to resolve.
+          (( delay=120 + RANDOM%120 ))
+          echo "Making ${delay} seconds pause before attempting a query"
+          sleep "${delay}"
+        fi
 
-        -- If the outcome is provided, set the job's end timestamp to "now" which is recorded in started_at.
-        UPDATE _SESSION.this_job
-        SET stopped_at = CASE
-            WHEN outcome IS NULL
-            THEN NULL
-            ELSE started_at
-          END
-        WHERE id = @id;
+        if bq query \
+            --use_legacy_sql=false \
+            --parameter="id::${PIPELINE_RUN_NAME}" \
+            --parameter="name::${ORIGINAL_PIPELINE_RUN_NAME}" \
+            --parameter="repo::${REPO_URL}" \
+            --parameter="branch::${SOURCE_BRANCH}" \
+            --parameter="pr_number:INTEGER:${PULL_REQUEST_NUMBER:-NULL}" \
+            --parameter="commit_sha::${COMMIT_SHA}" \
+            --parameter="outcome::${AGGREGATE_TASKS_STATUS:-NULL}" \
+            "
+            -- Create a temporary table for holding a record for this job with the same schema as the target table.
+            CREATE TEMP TABLE _SESSION.this_job AS SELECT * FROM ${TABLE_NAME} LIMIT 0;
 
-        -- Upsert a record from the temporary table into the target table.
-        MERGE INTO ${TABLE_NAME} T
-        USING _SESSION.this_job S
-        ON T.id = S.id
-        WHEN NOT MATCHED BY TARGET THEN
-          INSERT ROW
-        WHEN MATCHED THEN
-          UPDATE SET stopped_at = S.stopped_at, outcome = S.outcome;
+            -- Add the job's record into the temporary table.
+            INSERT INTO _SESSION.this_job
+              (id, name, repo, branch, pr_number, commit_sha, started_at, outcome, ci_system)
+              VALUES
+              (@id, @name, @repo, @branch, @pr_number, @commit_sha, CURRENT_TIMESTAMP(), @outcome, 'konflux');
 
-        -- Remove the temporary table (if not us, Google would remove it after 24 hours).
-        DROP TABLE _SESSION.this_job;
-        "
+            -- If the outcome is provided, set the job's end timestamp to "now" which is recorded in started_at.
+            UPDATE _SESSION.this_job
+            SET stopped_at = CASE
+                WHEN outcome IS NULL
+                THEN NULL
+                ELSE started_at
+              END
+            WHERE id = @id;
+
+            -- Upsert a record from the temporary table into the target table.
+            MERGE INTO ${TABLE_NAME} T
+            USING _SESSION.this_job S
+            ON T.id = S.id
+            WHEN NOT MATCHED BY TARGET THEN
+              INSERT ROW
+            WHEN MATCHED THEN
+              UPDATE SET stopped_at = S.stopped_at, outcome = S.outcome;
+
+            -- Remove the temporary table (if not us, Google would remove it after 24 hours).
+            DROP TABLE _SESSION.this_job;
+            "
+        then
+          (( successes+=1 ))
+          break
+        fi
+
+        (( errors+=1 ))
+      done
+
+      # Form and produce TEST_OUTPUT.
+      outcome=""
+      if (( successes > 0 )); then
+        outcome="SUCCESS"
+      else
+        outcome="WARNING"
+      fi
+      timestamp="$(date --rfc-3339=seconds | sed 's/ /T/')"
+      tee "$(results.TEST_OUTPUT.path)" <<EOF
+        {
+          "result": "${outcome}",
+          "timestamp": "${timestamp}",
+          "successes": "${successes}",
+          "failures": "0",
+          "warnings": "${errors}"
+        }
+      EOF

--- a/tasks/post-bigquery-metrics-task.yaml
+++ b/tasks/post-bigquery-metrics-task.yaml
@@ -101,6 +101,7 @@ spec:
 
       successes=0
       errors=0
+      note=''
 
       while (( errors < 3 )); do
         if (( errors > 0 )); then
@@ -158,6 +159,7 @@ spec:
         fi
 
         (( errors+=1 ))
+        note="There were errors updating BigQuery. See log."
       done
 
       # Form and produce TEST_OUTPUT.
@@ -174,6 +176,7 @@ spec:
           "timestamp": "${timestamp}",
           "successes": "${successes}",
           "failures": "0",
-          "warnings": "${errors}"
+          "warnings": "${errors}",
+          "note": "${note}"
         }
       EOF

--- a/tasks/post-bigquery-metrics-task.yaml
+++ b/tasks/post-bigquery-metrics-task.yaml
@@ -105,7 +105,8 @@ spec:
           sleep "${delay}"
         fi
 
-        if bq query \
+        # todo: un-negate
+        if ! bq query \
             --headless \
             --use_legacy_sql=false \
             --parameter="id::${ID}" \

--- a/tasks/post-bigquery-metrics-task.yaml
+++ b/tasks/post-bigquery-metrics-task.yaml
@@ -27,12 +27,6 @@ spec:
       When this task is at the beginning of the pipeline, don't pass anything.
       When the task is placed in the pipeline's finally block, pass here `$(tasks.status)`.
       Ref https://tekton.dev/docs/pipelines/pipelines/#using-aggregate-execution-status-of-all-tasks
-  results:
-  - name: TEST_OUTPUT
-    description: |
-      Indicates in a way that should not fail the overall pipeline whether metric posting succeeded.
-      The format is according to Konflux convention, see
-      https://konflux-ci.dev/architecture/ADR/0030-tekton-results-naming-convention.html
   volumes:
   - name: gcp-service-account
     secret:
@@ -101,7 +95,6 @@ spec:
 
       successes=0
       errors=0
-      note=''
 
       while (( errors < 3 )); do
         if (( errors > 0 )); then
@@ -159,24 +152,9 @@ spec:
         fi
 
         (( errors+=1 ))
-        note="There were errors updating BigQuery. See log."
       done
 
-      # Form and produce TEST_OUTPUT.
-      outcome=""
-      if (( successes > 0 )); then
-        outcome="SUCCESS"
-      else
-        outcome="WARNING"
+      if (( successes==0 )); then
+        echo >&2 "Could not put info in BigQuery."
+        exit 6
       fi
-      timestamp="$(date --rfc-3339=seconds | sed 's/ /T/')"
-      tee "$(results.TEST_OUTPUT.path)" <<EOF
-        {
-          "result": "${outcome}",
-          "timestamp": "${timestamp}",
-          "successes": "${successes}",
-          "failures": "0",
-          "warnings": "${errors}",
-          "note": "${note}"
-        }
-      EOF


### PR DESCRIPTION
### Notes

This follows up on https://github.com/stackrox/konflux-tasks/pull/41.
The moment I tried adding the task to the StackRox repo, it [failed](https://github.com/stackrox/stackrox/pull/14798/checks?check_run_id=39578621898) saying

> stackroxci:bqjob_r10d5eb469e0c999a_00000195dc572b29_1': Resources exceeded during query execution: Too many DML statements outstanding against table acs-san-stackroxci:ci_metrics.stackrox_jobs, limit is 20. at [21:3]

While I can't queue executions from different pipelines, I can at least add retries.
See related https://redhat-internal.slack.com/archives/C0321S70YK1/p1743159666168609?thread_ts=1731937635.189999&cid=C0321S70YK1

Also, there's likely a pipeline name uniqueness problem and this PR addressed that. Ref https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1743154987415819

Hint: this PR may be reviewed by commits.

### Testing

Via https://github.com/stackrox/scanner/pull/1851. See comments below.