### PR TITLE
ROX-27856: Insert two rows instead of insert+update

### DIFF
--- a/tasks/post-bigquery-metrics-task.yaml
+++ b/tasks/post-bigquery-metrics-task.yaml
@@ -89,6 +89,14 @@ spec:
 
       AGGREGATE_TASKS_STATUS="$(params.AGGREGATE_TASKS_STATUS)"
 
+      if [[ -z "${AGGREGATE_TASKS_STATUS}" ]]; then
+        started_at="CURRENT_TIMESTAMP()"
+        stopped_at="NULL"
+      else
+        started_at="NULL"
+        stopped_at="CURRENT_TIMESTAMP()"
+      fi
+
       # Even though PIPELINE_RUN_NAME looks unique, it's not guaranteed to be so. There's a chance the same entropy
       # suffix will be generated over a long period of time. Since we don't want metrics to clash, we append UUID.
       ID="${PIPELINE_RUN_NAME}.${PIPELINE_RUN_UID}"
@@ -116,35 +124,10 @@ spec:
             --parameter="commit_sha::${COMMIT_SHA}" \
             --parameter="outcome::${AGGREGATE_TASKS_STATUS:-NULL}" \
             "
-            -- Create a temporary table for holding a record for this job with the same schema as the target table.
-            CREATE TEMP TABLE _SESSION.this_job AS SELECT * FROM ${TABLE_NAME} LIMIT 0;
-
-            -- Add the job's record into the temporary table.
-            INSERT INTO _SESSION.this_job
-              (id, name, repo, branch, pr_number, commit_sha, started_at, outcome, ci_system)
+            INSERT INTO ${TABLE_NAME}
+              (id, name, repo, branch, pr_number, commit_sha, started_at, stopped_at, outcome, ci_system)
               VALUES
-              (@id, @name, @repo, @branch, @pr_number, @commit_sha, CURRENT_TIMESTAMP(), @outcome, 'konflux');
-
-            -- If the outcome is provided, set the job's end timestamp to "now" which is recorded in started_at.
-            UPDATE _SESSION.this_job
-            SET stopped_at = CASE
-                WHEN outcome IS NULL
-                THEN NULL
-                ELSE started_at
-              END
-            WHERE id = @id;
-
-            -- Upsert a record from the temporary table into the target table.
-            MERGE INTO ${TABLE_NAME} T
-            USING _SESSION.this_job S
-            ON T.id = S.id
-            WHEN NOT MATCHED BY TARGET THEN
-              INSERT ROW
-            WHEN MATCHED THEN
-              UPDATE SET stopped_at = S.stopped_at, outcome = S.outcome;
-
-            -- Remove the temporary table (if not us, Google would remove it after 24 hours).
-            DROP TABLE _SESSION.this_job;
+              (@id, @name, @repo, @branch, @pr_number, @commit_sha, ${started_at}, ${stopped_at}, @outcome, 'konflux')
             "
         then
           (( successes+=1 ))


### PR DESCRIPTION
### Description

BigQuery being analytical data store does not support primary keys or traditional indexes (the ones supported are for full text search and some vector approximation, see [here](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language)). Therefore, the update or upsert operations have to scan the entire table in order to identify required rows.
This would be no issue if we'd update/upsert in bulk and rarely but we do that by 1 record at a time. This means, every time the operation is `O(N)` where `N` is the amount of records in the table.

I suggest we change the approach for Konflux records and insert 1 record when the pipeline starts and 1 record when the pipeline ends. This may require changes to queries/dashboards that calculate the pipeline duration (we'd have to join table with itself on the `id`) but should not require changes to queries/dashboards that calculate the pipeline success rate if they filter by finished pipelines.

The insertion is just appending to the table and so it should be `O(1)` and so adding `M` metrics would be `O(M)` as opposed to `O((N+M)*M) = O(N*M) + O(M^2)` as in the upsert approach.
There will be an overhead of table join but that should be ok because (a) BigQuery is quite able to perform bulky queries, and (b) these queries don't run often, i.e. either on-demand or when dashboards are recomputed.

Discussion thread: https://redhat-internal.slack.com/archives/C0321S70YK1/p1743415461048929?thread_ts=1731937635.189999&cid=C0321S70YK1

After this change, the step container duration on two randomly sampled runs:
```
      Started:      Mon, 31 Mar 2025 16:12:15 +0200
      Finished:     Mon, 31 Mar 2025 16:12:29 +0200

      Started:      Mon, 31 Mar 2025 16:12:06 +0200
      Finished:     Mon, 31 Mar 2025 16:12:20 +0200
```

Before this change:
```
Initial insert:
      Started:      Thu, 03 Apr 2025 20:01:10 +0200
      Finished:     Thu, 03 Apr 2025 20:02:49 +0200

      Started:      Thu, 03 Apr 2025 20:01:06 +0200
      Finished:     Thu, 03 Apr 2025 20:02:52 +0200

Subsequent update:
      Started:      Thu, 03 Apr 2025 20:13:25 +0200
      Finished:     Thu, 03 Apr 2025 20:13:54 +0200

      Started:      Thu, 03 Apr 2025 20:16:28 +0200
      Finished:     Thu, 03 Apr 2025 20:16:58 +0200
```

The container execution time went down from ~30..90 seconds to ~15..20. This time includes authenticating to GCloud.
I don't think the time is guaranteed (I've seen runs ~5 minutes with the new task) but it's just an indication that it's becoming "not worse" that I was looking for.

### Testing

Tried in https://github.com/stackrox/scanner/pull/1851.