### PR TITLE
ROX-27901: Stop explicitly inheriting Konflux config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,7 +14,7 @@
     // We found out about it here (we may want to check that location if the base config gets suddenly moved):
     // https://github.com/enterprise-contract/ec-cli/blob/407847910ad420850385eea1db78e2a2e49c7e25/renovate.json#L1C1-L7C2
 
-    // This tells Renovate to combine all updates in one PR so that we have less PRs to deal with.
+    // This tells Renovate to combine all updates in one PR so that we have fewer PRs to deal with.
     "group:all",
   ],
   "timezone": "Etc/UTC",
@@ -39,7 +39,7 @@
     ],
     "automerge": true,
     // PRs can't be actually automerged because we require approval from CODEOWNERS which Renovate can't bypass,
-    // therefore we set automerge type to branch.
+    // therefore, we set automerge type to branch.
     "automergeType": "branch",
     "automergeStrategy": "squash",
     // Tell Renovate that it can automerge branches at any time of the day.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,11 +8,12 @@
 
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    // This inherits the base Konflux config.
-    // Clickable link https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json
-    // The following was used as example (we may want to check it if the base config gets suddenly moved):
+    // Note that the base Konflux's MintMaker config gets inherited/included automatically per
+    // https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1745492139282819?thread_ts=1745309786.090319&cid=C04PZ7H0VA8
+    // The config is: https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json
+    // We found out about it here (we may want to check that location if the base config gets suddenly moved):
     // https://github.com/enterprise-contract/ec-cli/blob/407847910ad420850385eea1db78e2a2e49c7e25/renovate.json#L1C1-L7C2
-    "github>konflux-ci/mintmaker//config/renovate/renovate.json",
+
     // This tells Renovate to combine all updates in one PR so that we have less PRs to deal with.
     "group:all",
   ],


### PR DESCRIPTION
In spite of repeated requests to stop explicitly depending on `"github>konflux-ci/mintmaker//config/renovate/renovate.json"`, I want to give it a try in this repo because we have evidence of MintMaker working ok and automerging.
- https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1742302893466149?thread_ts=1742299353.416699&cid=C04PZ7H0VA8
- https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1745492139282819?thread_ts=1745309786.090319&cid=C04PZ7H0VA8

## Validation

Only ran CLI for linting.
I don't know how the thing will be running but I'll observe this repo after merging.