### PR TITLE
ROX-27716: Add support for image tag suffix suppression

### DIFF
--- a/tasks/determine-image-tag-task.yaml
+++ b/tasks/determine-image-tag-task.yaml
@@ -3,10 +3,11 @@ kind: Task
 metadata:
   name: determine-image-tag
 spec:
-  description: Determines the tag for the output image using the StackRox convention from 'make tag' output.
+  description: Determines the tag for the output image using the StackRox conventions.
+    For development builds the tag comes from the output of 'make tag' command.
   params:
   - name: TAG_SUFFIX
-    description: Suffix to append to generated image tag.
+    description: Suffix to append to generated image tag. This suffix may be ignored under certain conditions.
     type: string
   - name: SOURCE_ARTIFACT
     description: The Trusted Artifact URI pointing to the artifact with the application source code. This should be the
@@ -41,6 +42,10 @@ spec:
     image: registry.access.redhat.com/ubi9:latest@sha256:304b50df1ea4db9706d8a30f4bbf26f582936ebc80c7e075c72ff2af99292a54
     workingDir: /var/workdir/source
     env:
+    - name: SOURCE_BRANCH
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.annotations['pipelinesascode.tekton.dev/source-branch']
     - name: TARGET_BRANCH
       valueFrom:
         fieldRef:
@@ -60,10 +65,11 @@ spec:
 
         fail_build_if_git_is_dirty
 
-        local -r suffix="$(params.TAG_SUFFIX)"
-
         local image_tag
         image_tag="$(determine_tag)"
+
+        local suffix
+        suffix="$(determine_tag_suffix)"
 
         echo -n "${image_tag}${suffix}" | tee "$(results.IMAGE_TAG.path)"
       }
@@ -83,11 +89,6 @@ spec:
       }
 
       function determine_tag() {
-        function log() {
-          # Log to stderr so not to mess up the function's printed result.
-          >&2 echo "$@"
-        }
-
         # 1. Gather data
 
         local tag_from_tekton=""
@@ -156,6 +157,33 @@ spec:
         return
       }
 
+      function determine_tag_suffix() {
+        local -r suffix_param="$(params.TAG_SUFFIX)"
+
+        if [[ "$(is_stackrox_repo)" == "no" ]]; then
+          log "This is not a StackRox repo, tag suffix will be: '${suffix_param}'."
+          echo "${suffix_param}"
+          return
+        fi
+
+        local -r script="scripts/ci/should-konflux-replace-gha-build.sh"
+
+        log "Checking if ${script} thinks the Konflux build should replace the GHA build."
+        local answer
+        answer="$( "${script}" )"
+        log "Script's answer: '${answer}'"
+
+        if [[ "${answer}" == "BUILD_AND_PUSH_ONLY_KONFLUX" ]]; then
+          log "Tag suffix will be suppressed."
+          echo ""
+          return
+        fi
+
+        log "Tag suffix '${suffix_param}' will be kept."
+        echo "${suffix_param}"
+        return
+      }
+
       # Differentiate stackrox/stackrox repo from stackrox/collector, stackrox/scanner and others.
       function is_stackrox_repo() {
         if [[ "${REPO_URL}" == "https://github.com/stackrox/stackrox" ]]; then
@@ -163,6 +191,11 @@ spec:
         else
           echo "no"
         fi
+      }
+
+      # Log to stderr so not to mess up the stdout result for any function which would use this function.
+      function log() {
+        >&2 echo ">>>" "$@"
       }
 
       main

--- a/tasks/determine-image-tag-task.yaml
+++ b/tasks/determine-image-tag-task.yaml
@@ -45,6 +45,11 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.annotations['pipelinesascode.tekton.dev/branch']
+    - name: REPO_URL
+      # E.g. "https://github.com/stackrox/stackrox"
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.annotations['pipelinesascode.tekton.dev/repo-url']
     script: |
       #!/usr/bin/env bash
 
@@ -151,13 +156,13 @@ spec:
         return
       }
 
-      # A poor-man's way to differentiate stackrox/stackrox repo from stackrox/collector, stackrox/scanner and others.
+      # Differentiate stackrox/stackrox repo from stackrox/collector, stackrox/scanner and others.
       function is_stackrox_repo() {
-        result="no"
-        if git remote -v | grep -qE '(\b)stackrox/stackrox(\b)'; then
-          result="yes"
+        if [[ "${REPO_URL}" == "https://github.com/stackrox/stackrox" ]]; then
+          echo "yes"
+        else
+          echo "no"
         fi
-        echo "${result}"
       }
 
       main

--- a/tasks/determine-image-tag-task.yaml
+++ b/tasks/determine-image-tag-task.yaml
@@ -16,11 +16,6 @@ spec:
     description: Directory in which to run 'make' command.
     type: string
     default: "."
-  - name: SOURCE_BRANCH
-    description: Branch (or tag) that triggered a build pipeline with this task.
-      Must be set to '{{ source_branch }}' Pipelines as Code variable.
-      See https://pipelinesascode.com/docs/guide/authoringprs/#dynamic-variables
-    type: string
   results:
   - name: IMAGE_TAG
     description: Image Tag determined by the custom logic.
@@ -45,6 +40,11 @@ spec:
   - name: determine-image-tag
     image: registry.access.redhat.com/ubi9:latest@sha256:304b50df1ea4db9706d8a30f4bbf26f582936ebc80c7e075c72ff2af99292a54
     workingDir: /var/workdir/source
+    env:
+    - name: SOURCE_BRANCH
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.annotations['pipelinesascode.tekton.dev/source-branch']
     script: |
       #!/usr/bin/env bash
 
@@ -56,7 +56,6 @@ spec:
         fail_build_if_git_is_dirty
 
         local -r suffix="$(params.TAG_SUFFIX)"
-        local -r source_branch="$(params.SOURCE_BRANCH)"
 
         local image_tag
         image_tag="$(determine_tag)"
@@ -87,10 +86,11 @@ spec:
         # 1. Gather data
 
         local tag_from_tekton=""
-        if [[ "${source_branch}" == refs/tags/* ]]; then
-          tag_from_tekton="${source_branch#refs/tags/}"
+        if [[ "${SOURCE_BRANCH}" == refs/tags/* ]]; then
+          tag_from_tekton="${SOURCE_BRANCH#refs/tags/}"
         fi
-        log "Tag from Tekton event: '${tag_from_tekton}'"
+        log "Source branch as reported by Tekton: '${SOURCE_BRANCH}'"
+        log "Tag from Tekton: '${tag_from_tekton}'"
 
         local tag_from_makefile
         tag_from_makefile="$(make -C "$(params.MAKEFILE_DIRECTORY)" --quiet --no-print-directory tag)"

--- a/tasks/determine-image-tag-task.yaml
+++ b/tasks/determine-image-tag-task.yaml
@@ -41,10 +41,10 @@ spec:
     image: registry.access.redhat.com/ubi9:latest@sha256:304b50df1ea4db9706d8a30f4bbf26f582936ebc80c7e075c72ff2af99292a54
     workingDir: /var/workdir/source
     env:
-    - name: SOURCE_BRANCH
+    - name: TARGET_BRANCH
       valueFrom:
         fieldRef:
-          fieldPath: metadata.annotations['pipelinesascode.tekton.dev/source-branch']
+          fieldPath: metadata.annotations['pipelinesascode.tekton.dev/branch']
     script: |
       #!/usr/bin/env bash
 
@@ -86,10 +86,10 @@ spec:
         # 1. Gather data
 
         local tag_from_tekton=""
-        if [[ "${SOURCE_BRANCH}" == refs/tags/* ]]; then
-          tag_from_tekton="${SOURCE_BRANCH#refs/tags/}"
+        if [[ "${TARGET_BRANCH}" == refs/tags/* ]]; then
+          tag_from_tekton="${TARGET_BRANCH#refs/tags/}"
         fi
-        log "Source branch as reported by Tekton: '${SOURCE_BRANCH}'"
+        log "Target branch as reported by Tekton: '${TARGET_BRANCH}'"
         log "Tag from Tekton: '${tag_from_tekton}'"
 
         local tag_from_makefile


### PR DESCRIPTION
Per title and ticket.

Paired with https://github.com/stackrox/stackrox/pull/15309

The PR can be reviewed by commits.

### Validation

- Default (unchanged) behavior in https://github.com/stackrox/stackrox/pull/15309
- PR with a special branch in https://github.com/stackrox/stackrox/pull/15351
- `release-x.y` branch with the holdfile still in place. https://github.com/stackrox/stackrox/commit/de7008cd0cedf37716985db8c28f12f0a13c6693
- `release-x.y` branch without the holdfile. https://github.com/stackrox/stackrox/commit/4edaeb73a3e71a6ad2d652715a9f349b04e0050b
- I did not validate how it works with PRs targeting release branch, nor with tag pushes. I hope that's going to just work, or we'll find it out.

The basic behavior is expected: the suppression happens when I programmed it and does not happen when I programmed it not to.
There's a deeper issue that even in the release branch tags don't match and so e2e tests fail unable to find images but that's something to be solved separately.