### PR TITLE
ROX-29410: Apply a unique tag to the images on build

### DIFF
--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -496,7 +496,7 @@ spec:
           script: |
             #!/usr/bin/env bash
             set -euo pipefail
-            echo -n "$(params.output-image-tag)-should-persist-$( date +%Y-%m-%d-%H-%M-%S.%N )" | tee "$(results.UNIQUE_TAG.path)"
+            echo -n "keep-image-$(params.output-image-tag)-$( date +%Y-%m-%d-%H-%M-%S.%N )" | tee "$(results.UNIQUE_TAG.path)"
 
     - name: apply-tags
       params:

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -477,27 +477,32 @@ spec:
             echo -n "${floating_tag}" | tee "$(results.FLOATING_TAG.path)"
 
     - name: generate-unique-tag
-      # todo: why?
-      params:
-      - name: label-templates
-        value:
-        - $(params.output-image-tag)-should-persist-$ACTUAL_DATE_EPOCH
-      taskRef:
-        params:
-        - name: name
-          value: generate-labels
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-generate-labels:0.1@sha256:b4c4f74d891d92b6715e86132889a51d142875ed3a565567e8167fdc4af1b360
-        - name: kind
-          value: task
-        resolver: bundles
+      description: Generates a unique tag to apply to the resulting images.
+        Both $(params.output-image-tag) and $(tasks.get-floating-tag.results.FLOATING_TAG) are practically floating tags
+        and will be moved when the pipeline gets re-triggered for the same commit or runs for subsequent commits
+        (respectively). Once they both get moved and there's no more tag pointing at this image, Quay will
+        garbage collect it. This creates a problem for images built for master if they happen to get used in any of the
+        repos - builds in these repos will fail once the image is gone. Therefore, this task generates a unique image
+        tag for each build which won't get moved and so Quay will keep the image. There's ROX-27836 to prevent garbage
+        piling up.
+      taskSpec:
+        results:
+        - name: UNIQUE_TAG
+          description: Unique tag to apply to the resulting images.
+        steps:
+        - name: generate-unique-tag
+          image: registry.redhat.io/ubi9-minimal:latest@sha256:92b1d5747a93608b6adb64dfd54515c3c5a360802db4706765ff3d8470df6290
+          script: |
+            #!/usr/bin/env bash
+            set -euo pipefail
+            echo -n "$(params.output-image-tag)-should-persist-$( date +%Y-%m-%d-%H-%M-%S.%N )" | tee "$(results.UNIQUE_TAG.path)"
 
     - name: apply-tags
       params:
       - name: IMAGE
         value: $(tasks.build-container.results.IMAGE_URL)
       - name: ADDITIONAL_TAGS
-        value: [$(tasks.get-floating-tag.results.FLOATING_TAG), "$(tasks.generate-unique-tag.results.labels[*])"]
+        value: [ $(tasks.get-floating-tag.results.FLOATING_TAG), $(tasks.generate-unique-tag.results.UNIQUE_TAG) ]
       taskRef:
         params:
         - name: name
@@ -630,3 +635,22 @@ spec:
             fi
 
             echo ">>> Done"
+
+    - name: apply-tags-trust
+      params:
+      - name: IMAGE
+        value: $(params.output-trust-data-repo):$(tasks.get-floating-tag.results.FLOATING_TAG)
+      - name: ADDITIONAL_TAGS
+        value: [ $(tasks.generate-unique-tag.results.UNIQUE_TAG) ]
+      runAfter:
+      # Explicit dependency on `update-tasks-trust` because that one pushes the image.
+      - update-tasks-trust
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:9d9871143ab3a818f681488be6074f5b2f892c1843795a46f6daf3f5487e72d1
+        - name: kind
+          value: task
+        resolver: bundles

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -476,12 +476,28 @@ spec:
 
             echo -n "${floating_tag}" | tee "$(results.FLOATING_TAG.path)"
 
+    - name: generate-unique-tag
+      # todo: why?
+      params:
+      - name: label-templates
+        value:
+        - $(params.output-image-tag)-should-persist-$ACTUAL_DATE_EPOCH
+      taskRef:
+        params:
+        - name: name
+          value: generate-labels
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-generate-labels:0.1@sha256:b4c4f74d891d92b6715e86132889a51d142875ed3a565567e8167fdc4af1b360
+        - name: kind
+          value: task
+        resolver: bundles
+
     - name: apply-tags
       params:
       - name: IMAGE
         value: $(tasks.build-container.results.IMAGE_URL)
       - name: ADDITIONAL_TAGS
-        value: [$(tasks.get-floating-tag.results.FLOATING_TAG)]
+        value: [$(tasks.get-floating-tag.results.FLOATING_TAG), "$(tasks.generate-unique-tag.results.labels[*])"]
       taskRef:
         params:
         - name: name

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -447,7 +447,7 @@ spec:
 
     - name: get-floating-tag
       description: Determines a floating tag that should be applied to the resulting images.
-        The tasks image should be referenced by this floating tag in the Tekton pipelines which use it.
+        The tasks image should be referenced by this floating tag and digest in the Tekton pipelines which use it.
       taskSpec:
         results:
         - name: FLOATING_TAG

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -447,6 +447,7 @@ spec:
 
     - name: get-floating-tag
       description: Determines a floating tag that should be applied to the resulting images.
+        The tasks image should be referenced by this floating tag in the Tekton pipelines which use it.
       taskSpec:
         results:
         - name: FLOATING_TAG
@@ -481,10 +482,10 @@ spec:
         Both $(params.output-image-tag) and $(tasks.get-floating-tag.results.FLOATING_TAG) are practically floating tags
         and will be moved when the pipeline gets re-triggered for the same commit or runs for subsequent commits
         (respectively). Once they both get moved and there's no more tag pointing at this image, Quay will
-        garbage collect it. This creates a problem for images built for master if they happen to get used in any of the
-        repos - builds in these repos will fail once the image is gone. Therefore, this task generates a unique image
-        tag for each build which won't get moved and so Quay will keep the image. There's ROX-27836 to prevent garbage
-        piling up.
+        garbage collect it. This creates a problem for images built in the main branch if they happen to get used in any
+        of the repos - builds in these repos will fail once the image is gone. Therefore, this task generates a unique
+        image tag for each build which won't get moved and so Quay will keep the image. There's ROX-27836 to prevent
+        garbage piling up.
       taskSpec:
         results:
         - name: UNIQUE_TAG
@@ -643,7 +644,7 @@ spec:
       - name: ADDITIONAL_TAGS
         value: [ $(tasks.generate-unique-tag.results.UNIQUE_TAG) ]
       runAfter:
-      # Explicit dependency on `update-tasks-trust` because that one pushes the image.
+      # Explicit dependency on `update-tasks-trust` because that one pushes the trust image.
       - update-tasks-trust
       taskRef:
         params:


### PR DESCRIPTION
So that images don't get GC-ed by quay.io when all floating tags move somewhere else.

## Validation

- Checked that the tasks image gets tagged:
```bash
$ oras discover quay.io/rhacs-eng/konflux-tasks:rev-1f4b6497de7ae6f642cbded470a485adb7032f05
quay.io/rhacs-eng/konflux-tasks@sha256:43074c901e25f348c6eac472708563327a496621dfaddc33562e5a39a21850b2
└── application/sarif+json
    └── sha256:47aabffacf436528ecdfca8e84ab0f0f1f0b695ebe3997b53cae855e54a180c0

$ oras discover quay.io/rhacs-eng/konflux-tasks:pr-57
quay.io/rhacs-eng/konflux-tasks@sha256:43074c901e25f348c6eac472708563327a496621dfaddc33562e5a39a21850b2
└── application/sarif+json
    └── sha256:47aabffacf436528ecdfca8e84ab0f0f1f0b695ebe3997b53cae855e54a180c0

$ oras discover quay.io/rhacs-eng/konflux-tasks:rev-1f4b6497de7ae6f642cbded470a485adb7032f05-should-persist-2025-05-21-11-33-02.841151128
quay.io/rhacs-eng/konflux-tasks@sha256:43074c901e25f348c6eac472708563327a496621dfaddc33562e5a39a21850b2
└── application/sarif+json
    └── sha256:47aabffacf436528ecdfca8e84ab0f0f1f0b695ebe3997b53cae855e54a180c0
```
All resolve to the same digest.

- Checked that the trust image gets tagged:
```bash
$ oras discover quay.io/rhacs-eng/konflux-tasks-trust:pr-57
quay.io/rhacs-eng/konflux-tasks-trust@sha256:1c7915f389e9cb5e092bc78edea488ddeeb3db9419148bbad0f92fc0bbd45c08

$ oras discover quay.io/rhacs-eng/konflux-tasks-trust:rev-1f4b6497de7ae6f642cbded470a485adb7032f05-should-persist-2025-05-21-11-33-02.841151128
quay.io/rhacs-eng/konflux-tasks-trust@sha256:1c7915f389e9cb5e092bc78edea488ddeeb3db9419148bbad0f92fc0bbd45c08
```