### PR TITLE
ROX-28973: retest-comment uses git tag if available

### DIFF
--- a/tasks/determine-image-expiration-task.yaml
+++ b/tasks/determine-image-expiration-task.yaml
@@ -54,7 +54,7 @@ spec:
       echo "Event type: ${PIPELINE_EVENT_TYPE}"
       echo "Target branch: ${PIPELINE_TARGET_BRANCH}"
 
-      local is_retest_tagged_build="no"
+      is_retest_tagged_build="no"
       if [[ "${PIPELINE_EVENT_TYPE}" == "retest-comment" ]]; then
         echo "This is a retested build, checking if tagged."
         dnf -y install git

--- a/tasks/determine-image-expiration-task.yaml
+++ b/tasks/determine-image-expiration-task.yaml
@@ -66,7 +66,7 @@ spec:
       fi
 
       # TODO(ROX-28001): Update the expiration logic for -fast releases.
-      if [[ "${PIPELINE_EVENT_TYPE}" != "pull_request" && (("${PIPELINE_TARGET_BRANCH}" == refs/tags/* && "${PIPELINE_TARGET_BRANCH}" != *-nightly-*) || is_retest_tagged_build == "yes") ]]; then
+      if [[ "${PIPELINE_EVENT_TYPE}" != "pull_request" && (("${PIPELINE_TARGET_BRANCH}" == refs/tags/* && "${PIPELINE_TARGET_BRANCH}" != *-nightly-*) || "${is_retest_tagged_build}" == "yes") ]]; then
         echo "This is a tagged build and not a nightly. The images won't expire. IMAGE_EXPIRES_AFTER will be empty."
         IMAGE_EXPIRES_AFTER=""
       else

--- a/tasks/determine-image-expiration-task.yaml
+++ b/tasks/determine-image-expiration-task.yaml
@@ -7,7 +7,7 @@ spec:
   params:
   - name: SOURCE_ARTIFACT
     description: The Trusted Artifact URI pointing to the artifact with the application source code. This should be the
-      result of the git-clone task, results from other tasks might fail as dirty.
+      result of the git-clone task.
     type: string
   - name: DEFAULT_IMAGE_EXPIRES_AFTER
     description: Default image expiration.
@@ -59,7 +59,7 @@ spec:
         echo "This is a retested build, checking if tagged."
         dnf -y install git
 
-        if [ -n "$(git tag --points-at)" ]; then
+        if [[ -n "$(git tag --points-at)" ]]; then
           echo "This is retested pipelinerun of a tagged build"
           is_retest_tagged_build="yes"
         fi

--- a/tasks/determine-image-expiration-task.yaml
+++ b/tasks/determine-image-expiration-task.yaml
@@ -15,6 +15,13 @@ spec:
   results:
   - name: IMAGE_EXPIRES_AFTER
     description: Image expiration as a duration, e.g. `13w`.
+  volumes:
+  - name: workdir
+    emptyDir: { }
+  stepTemplate:
+    volumeMounts:
+    - mountPath: /var/workdir
+      name: workdir
   steps:
   - name: use-trusted-artifact
     image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
@@ -37,6 +44,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.annotations['build.appstudio.redhat.com/target_branch']
+    workingDir: /var/workdir/source
     script: |
       #!/usr/bin/env bash
 

--- a/tasks/determine-image-expiration-task.yaml
+++ b/tasks/determine-image-expiration-task.yaml
@@ -48,10 +48,11 @@ spec:
 
       local is_retest_tagged_build="no"
       if [[ "${PIPELINE_EVENT_TYPE}" == "retest-comment" ]]; then
-        echo "This is a retested buid, checking if tagged."
+        echo "This is a retested build, checking if tagged."
         dnf -y install git
 
         if [ "$(git tag --points-at | wc -l)" -gt 0 ]; then
+          echo "This is retested pipelinerun of a tagged build"
           is_retest_tagged_build="yes"
         fi
       fi

--- a/tasks/determine-image-expiration-task.yaml
+++ b/tasks/determine-image-expiration-task.yaml
@@ -34,7 +34,8 @@ spec:
     - use
     - $(params.SOURCE_ARTIFACT)=/var/workdir/source
   - name: determine-image-expiration
-    image: registry.access.redhat.com/ubi9:latest@sha256:304b50df1ea4db9706d8a30f4bbf26f582936ebc80c7e075c72ff2af99292a54
+    # We need git and toolbox image has it.
+    image: registry.access.redhat.com/ubi9/toolbox:latest@sha256:e6df0f2df988f93e27c0dfb959bd116ccf63bca2d07e1a857b970799ac8167f9
     env:
     - name: PIPELINE_EVENT_TYPE
       valueFrom:
@@ -57,8 +58,6 @@ spec:
       is_retest_tagged_build="no"
       if [[ "${PIPELINE_EVENT_TYPE}" == "retest-comment" ]]; then
         echo "This is a retested build, checking if tagged."
-        dnf -y install git
-
         if [[ -n "$(git tag --points-at)" ]]; then
           echo "This is retested pipelinerun of a tagged build"
           is_retest_tagged_build="yes"

--- a/tasks/determine-image-expiration-task.yaml
+++ b/tasks/determine-image-expiration-task.yaml
@@ -59,7 +59,7 @@ spec:
         echo "This is a retested build, checking if tagged."
         dnf -y install git
 
-        if [ "$(git tag --points-at | wc -l)" -gt 0 ]; then
+        if [ -n "$(git tag --points-at)" ]; then
           echo "This is retested pipelinerun of a tagged build"
           is_retest_tagged_build="yes"
         fi

--- a/tasks/determine-image-expiration-task.yaml
+++ b/tasks/determine-image-expiration-task.yaml
@@ -5,6 +5,10 @@ metadata:
 spec:
   description: Determines the image expiration parameter, or sets to empty for git-tagged builds.
   params:
+  - name: SOURCE_ARTIFACT
+    description: The Trusted Artifact URI pointing to the artifact with the application source code. This should be the
+      result of the git-clone task, results from other tasks might fail as dirty.
+    type: string
   - name: DEFAULT_IMAGE_EXPIRES_AFTER
     description: Default image expiration.
     type: string
@@ -12,6 +16,16 @@ spec:
   - name: IMAGE_EXPIRES_AFTER
     description: Image expiration as a duration, e.g. `13w`.
   steps:
+  - name: use-trusted-artifact
+    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
+    computeResources:
+      requests:
+        memory: 2Gi
+      limits:
+        memory: 2Gi
+    args:
+    - use
+    - $(params.SOURCE_ARTIFACT)=/var/workdir/source
   - name: determine-image-expiration
     image: registry.access.redhat.com/ubi9:latest@sha256:304b50df1ea4db9706d8a30f4bbf26f582936ebc80c7e075c72ff2af99292a54
     env:
@@ -32,8 +46,18 @@ spec:
       echo "Event type: ${PIPELINE_EVENT_TYPE}"
       echo "Target branch: ${PIPELINE_TARGET_BRANCH}"
 
+      local is_retest_tagged_build="no"
+      if [[ "${PIPELINE_EVENT_TYPE}" == "retest-comment" ]]; then
+        echo "This is a retested buid, checking if tagged."
+        dnf -y install git
+
+        if [ "$(git tag --points-at | wc -l)" -gt 0 ]; then
+          is_retest_tagged_build="yes"
+        fi
+      fi
+
       # TODO(ROX-28001): Update the expiration logic for -fast releases.
-      if [[ "${PIPELINE_EVENT_TYPE}" != "pull_request" && "${PIPELINE_TARGET_BRANCH}" == refs/tags/* && "${PIPELINE_TARGET_BRANCH}" != *-nightly-* ]]; then
+      if [[ "${PIPELINE_EVENT_TYPE}" != "pull_request" && (("${PIPELINE_TARGET_BRANCH}" == refs/tags/* && "${PIPELINE_TARGET_BRANCH}" != *-nightly-*) || is_retest_tagged_build == "yes") ]]; then
         echo "This is a tagged build and not a nightly. The images won't expire. IMAGE_EXPIRES_AFTER will be empty."
         IMAGE_EXPIRES_AFTER=""
       else

--- a/tasks/determine-image-tag-task.yaml
+++ b/tasks/determine-image-tag-task.yaml
@@ -45,6 +45,11 @@ spec:
   - name: determine-image-tag
     image: registry.access.redhat.com/ubi9:latest@sha256:304b50df1ea4db9706d8a30f4bbf26f582936ebc80c7e075c72ff2af99292a54
     workingDir: /var/workdir/source
+    env:
+    - name: EVENT_TYPE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.labels['pipelinesascode.tekton.dev/event-type']
     script: |
       #!/usr/bin/env bash
 
@@ -84,6 +89,21 @@ spec:
           >&2 echo "$@"
         }
 
+        # Retested tagged builds should use first tag that they see.
+        if [[ "${EVENT_TYPE}" == "retest-comment" ]]; then
+          log "Retested pipeline. Testing if this commit is tagged."
+
+          local tags_from_git
+          tags_from_git="$(git tag --points-at)"
+          local -a tags_from_git_arr
+          readarray -t tags_from_git_arr <<< "${tags_from_git}"
+          log "Tags seen by git: '${tags_from_git_arr[*]}'"
+
+          if [ "${#tags_from_git_arr[@]}" -gt 0 ]; then
+
+          fi
+        fi
+
         # 1. Gather data
 
         local tag_from_tekton=""
@@ -122,6 +142,17 @@ spec:
           log "This seems to be a tekton tag push event, using ${tag_from_tekton} for the tag."
           echo "${tag_from_tekton}"
           return
+        fi
+
+        if [[ "${EVENT_TYPE}" == "retest-comment" ]]; then
+          log "This seems to be a retest of a pipeline run, checking if this is for a tagged build."
+          if [ "${#tags_from_git_arr[@]}" -gt 0 ]; then
+            log "This seems to be a re-run of a tagged build, using the first tag ${tags_from_git_arr[0]}."
+            echo "${tags_from_git_arr[0]}"
+            return
+          else
+            log "This is not a tagged build, so continuing with normal logic."
+          fi
         fi
 
         # Handle the special case in the Collector repo.

--- a/tasks/determine-image-tag-task.yaml
+++ b/tasks/determine-image-tag-task.yaml
@@ -137,7 +137,7 @@ spec:
         if [[ "${PIPELINE_EVENT_TYPE}" == "retest-comment" ]]; then
           log "This seems to be a retest of a pipeline run, checking if this is for a tagged build."
           tag="$(git tag --points-at | head -n 1)"
-          if [ -n "${tag}" ]; then
+          if [[ -n "${tag}" ]]; then
             log "This seems to be a re-run of a tagged build, using the first tag detected: ${tag}."
             echo "${tag}"
             return

--- a/tasks/determine-image-tag-task.yaml
+++ b/tasks/determine-image-tag-task.yaml
@@ -136,9 +136,10 @@ spec:
 
         if [[ "${PIPELINE_EVENT_TYPE}" == "retest-comment" ]]; then
           log "This seems to be a retest of a pipeline run, checking if this is for a tagged build."
-          if [ "${#tags_from_git_arr[@]}" -gt 0 ]; then
-            log "This seems to be a re-run of a tagged build, using the first tag ${tags_from_git_arr[0]}."
-            echo "${tags_from_git_arr[0]}"
+          tag=$(git tag --points-at | head -n 1)
+          if [ -n "${tag}" ]; then
+            log "This seems to be a re-run of a tagged build, using the first tag detected: ${tag}."
+            echo "${tag}"
             return
           else
             log "This is not a tagged build, so continuing with normal logic."

--- a/tasks/determine-image-tag-task.yaml
+++ b/tasks/determine-image-tag-task.yaml
@@ -119,7 +119,7 @@ spec:
         local tags_from_git
         tags_from_git="$(git tag --points-at)"
         local -a tags_from_git_arr
-        readarray -t tags_from_git_arr <<< "${tags_from_git}"
+        readarray -t tags_from_git_arr < <(printf '%s' "$tags_from_git")
         log "Tags seen by git: '${tags_from_git_arr[*]}'"
 
         local git_describe_output
@@ -136,10 +136,9 @@ spec:
 
         if [[ "${PIPELINE_EVENT_TYPE}" == "retest-comment" ]]; then
           log "This seems to be a retest of a pipeline run, checking if this is for a tagged build."
-          tag="$(git tag --points-at | head -n 1)"
-          if [[ -n "${tag}" ]]; then
-            log "This seems to be a re-run of a tagged build, using the first tag detected: ${tag}."
-            echo "${tag}"
+          if [[ "${#tags_from_git_arr[*]}" -gt 0 ]]; then
+            log "This seems to be a re-run of a tagged build, using the first tag detected: ${tags_from_git_arr[0]}."
+            echo "${tags_from_git_arr[0]}"
             return
           else
             log "This is not a tagged build, so continuing with normal logic."

--- a/tasks/determine-image-tag-task.yaml
+++ b/tasks/determine-image-tag-task.yaml
@@ -136,7 +136,7 @@ spec:
 
         if [[ "${PIPELINE_EVENT_TYPE}" == "retest-comment" ]]; then
           log "This seems to be a retest of a pipeline run, checking if this is for a tagged build."
-          tag=$(git tag --points-at | head -n 1)
+          tag="$(git tag --points-at | head -n 1)"
           if [ -n "${tag}" ]; then
             log "This seems to be a re-run of a tagged build, using the first tag detected: ${tag}."
             echo "${tag}"

--- a/tasks/determine-image-tag-task.yaml
+++ b/tasks/determine-image-tag-task.yaml
@@ -46,7 +46,7 @@ spec:
     image: registry.access.redhat.com/ubi9:latest@sha256:304b50df1ea4db9706d8a30f4bbf26f582936ebc80c7e075c72ff2af99292a54
     workingDir: /var/workdir/source
     env:
-    - name: EVENT_TYPE
+    - name: PIPELINE_EVENT_TYPE
       valueFrom:
         fieldRef:
           fieldPath: metadata.labels['pipelinesascode.tekton.dev/event-type']
@@ -129,7 +129,7 @@ spec:
           return
         fi
 
-        if [[ "${EVENT_TYPE}" == "retest-comment" ]]; then
+        if [[ "${PIPELINE_EVENT_TYPE}" == "retest-comment" ]]; then
           log "This seems to be a retest of a pipeline run, checking if this is for a tagged build."
           if [ "${#tags_from_git_arr[@]}" -gt 0 ]; then
             log "This seems to be a re-run of a tagged build, using the first tag ${tags_from_git_arr[0]}."

--- a/tasks/determine-image-tag-task.yaml
+++ b/tasks/determine-image-tag-task.yaml
@@ -89,21 +89,6 @@ spec:
           >&2 echo "$@"
         }
 
-        # Retested tagged builds should use first tag that they see.
-        if [[ "${EVENT_TYPE}" == "retest-comment" ]]; then
-          log "Retested pipeline. Testing if this commit is tagged."
-
-          local tags_from_git
-          tags_from_git="$(git tag --points-at)"
-          local -a tags_from_git_arr
-          readarray -t tags_from_git_arr <<< "${tags_from_git}"
-          log "Tags seen by git: '${tags_from_git_arr[*]}'"
-
-          if [ "${#tags_from_git_arr[@]}" -gt 0 ]; then
-
-          fi
-        fi
-
         # 1. Gather data
 
         local tag_from_tekton=""


### PR DESCRIPTION
## Testing: 
  * [x] branch build: expect expiration and git describe-style tag
    * https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/pipelineruns/central-db-on-push-9gk22
  * [x] retest of branch build: expect expiraton and git describe-style tag
    * https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/pipelineruns/central-db-on-push-6l8p9, triggered by https://github.com/stackrox/stackrox/commit/3a11acbaf91a9f33e0ab117a54cc1eeb19c571aa#commitcomment-158023352
  * [x] tagged build: expect no expiration and x.y.z
    * https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/pipelineruns/central-db-on-push-mzvt8 (added tag after previous experiment "retest of branch build" succeeded)
  * [x] retest of tagged build: expect no expiration and x.y.z
    * https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/pipelineruns/central-db-on-push-4jjx7, triggered by https://github.com/stackrox/stackrox/commit/3a11acbaf91a9f33e0ab117a54cc1eeb19c571aa#commitcomment-158023584
  * [x] pull request: expect expiration and git describe-style tag
    * https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/pipelineruns/central-db-on-push-gxjfj, on https://github.com/stackrox/stackrox/pull/15428
  * [x] retest of pull request: expect expiration and git describe-style tag
    * https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/pipelineruns/central-db-on-push-t4tsp, triggered by https://github.com/stackrox/stackrox/pull/15428#issuecomment-2909609260
    
    
Note: I cancelled some pipelines to move faster. You can verify that the changes works as expected by looking at the results of `determine-image-expiration` and `determine-image-tag` respectively. 

Required changes to the build pipelines are shown in https://github.com/stackrox/stackrox/pull/15428/files, namely:
* updating the konflux-tasks image digests
* moving determine-image-expiration after `clone-repository` (it needs to run a git command in the workspace)
  * adding the source artifact (TA) to the `determine-image-expiration` input parameters to load the workspace.