### PR TITLE
ROX-29478: Revise `-fast` suffix suppression

### DIFF
--- a/tasks/determine-image-tag-task.yaml
+++ b/tasks/determine-image-tag-task.yaml
@@ -172,29 +172,34 @@ spec:
         return
       }
 
+      # determine_tag_suffix omits the image tag suffix for Stable Stream release (and release-like) builds.
       function determine_tag_suffix() {
         local -r suffix_param="$(params.TAG_SUFFIX)"
 
         if [[ "$(is_stackrox_repo)" == "no" ]]; then
-          log "This is not a StackRox repo, tag suffix will be: '${suffix_param}'."
+          log "This is not a StackRox repo, using '${suffix_param}' as the tag suffix."
           echo "${suffix_param}"
           return
         fi
 
-        local -r script="scripts/ci/should-konflux-replace-gha-build.sh"
+        log "Konflux TARGET_BRANCH: ${TARGET_BRANCH}"
+        log "Konflux SOURCE_BRANCH: ${SOURCE_BRANCH}"
 
-        log "Checking if ${script} thinks the Konflux build should replace the GHA build."
-        local answer
-        answer="$( "${script}" )"
-        log "Script's answer: '${answer}'"
+        if [[ "${SOURCE_BRANCH}" == *konflux-release-like* ]]; then
+          log "This looks like a PR branch containing the magic string. The tag suffix is suppressed."
+          echo ""
+          return
+        else
+          log "Did not spot the magic string in the SOURCE_BRANCH."
+        fi
 
-        if [[ "${answer}" == "BUILD_AND_PUSH_ONLY_KONFLUX" ]]; then
-          log "Tag suffix will be suppressed."
+        if grep -qE '^(release-[0-9a-z]+\.[0-9a-z]+|refs/tags/[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?)$' <<< "${TARGET_BRANCH}"; then
+          log "This looks like a release branch or release tag push, or PR targeting the release branch. The tag suffix is suppressed."
           echo ""
           return
         fi
 
-        log "Tag suffix '${suffix_param}' will be kept."
+        log "This does not look like a release branch or release tag push, nor like PR targeting the release branch. Using '${suffix_param}' as the tag suffix."
         echo "${suffix_param}"
         return
       }


### PR DESCRIPTION
This follows up on https://github.com/stackrox/konflux-tasks/pull/55 and modifies the approach per ticket.
Goes together with https://github.com/stackrox/stackrox/pull/15442

Note regarding <https://github.com/stackrox/konflux-tasks/pull/58#discussion_r2107329323>: it does not seem necessary to adjust the suffix suppression logic when the build is triggered by a retest comment.
The reason is that we want to re-trigger release-tagged builds and we know that these release tags live on release branches. In that case, Konflux will populate `TARGET_BRANCH`/`SOURCE_BRANCH` with release branch name instead of the release tag name, but either is sufficient to trigger the suffix suppression logic.

The same actually applied to the original code of https://github.com/stackrox/stackrox/blob/843057035c7f8151b3ac4303657229d96f791e5d/scripts/ci/should-konflux-replace-gha-build.sh but I did not realize it then. Was it premature to take https://issues.redhat.com/browse/ROX-29479? I don't think so, I think it's the right thing to do.

### Validation

See notes on testing below.