### PR TITLE
ROX-29484: allow retests for branch PipelineRuns

### DIFF
--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -483,16 +483,13 @@ spec:
               fi
             fi
 
-            if [[ "${PIPELINE_EVENT_TYPE}" == "push" ]]; then
+            if [[ "${PIPELINE_EVENT_TYPE}" == "pull_request" ]]; then
+              floating_tag="pr-${PULL_REQUEST_NUMBER}"
+            else
               floating_tag="$(echo "${SOURCE_BRANCH}" | sed 's/[^a-zA-Z0-9_.]/-/g')"
               if [[ "${SOURCE_BRANCH}" == "main" ]]; then
                 floating_tag="latest"
               fi
-            elif [[ "${PIPELINE_EVENT_TYPE}" == "pull_request" ]]; then
-              floating_tag="pr-${PULL_REQUEST_NUMBER}"
-            else
-              echo "ERROR: Unknown PIPELINE_EVENT_TYPE"
-              exit 1
             fi
 
             echo -n "${floating_tag}" | tee "$(results.FLOATING_TAG.path)"

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -10,7 +10,7 @@ metadata:
     # The on-push filter includes konflux/* branches which are created by Mintmaker so that CI runs for commits pushed
     # onto these branches even without PRs and so that Mintmaker/Renovate can automerge its updates without PRs.
     pipelinesascode.tekton.dev/on-cel-expression: |
-      (event == "push" && target_branch.matches("^(main|konflux/references/main|konflux/mintmaker/.*|tm/ROX-29484-fix-retest-comments)$")) ||
+      (event == "push" && target_branch.matches("^(main|konflux/references/main|konflux/mintmaker/.*)$")) ||
       (event == "pull_request")
   creationTimestamp:
   labels:

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -479,7 +479,7 @@ spec:
             echo "Target branch: ${TARGET_BRANCH}"
             echo "Pull request number: ${PULL_REQUEST_NUMBER}"
 
-            if [[ "${PIPELINE_EVENT_TYPE}" == "retest-comment" || "${PIPELINE_EVENT_TYPE}" == "retest-all-comment" ]]; then
+            if [[ "${PIPELINE_EVENT_TYPE}" =~ ^(re)?test-(all-)?comment$ ]]; then
               if [[ "${SOURCE_BRANCH}" != "${TARGET_BRANCH}" ]]; then
                 # This is a retest of a Pull Request, because SOURCE and TARGET branch are different.
                 # We are comparing those, because it's easier than attempting to detect if PULL_REQUEST_NUMBER is templated or not.

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -475,7 +475,7 @@ spec:
             echo "Pull request number: ${PULL_REQUEST_NUMBER}"
 
             if [[ "${PIPELINE_EVENT_TYPE}" == "retest-comment" || "${PIPELINE_EVENT_TYPE}" == "retest-all-comment" ]]; then
-              if [[ "${PULL_REQUEST_NUMBER}" == "pull_request_number" ]]; then
+              if [[ "${PULL_REQUEST_NUMBER}" == "{{pull_request_number}}" ]]; then
                 # This is not a retest of a Pull Request, because PULL_REQUEST_NUMBER is not filled.
                 # This must be a branch or tagged build, so we overwrite the PIPELINE_EVENT_TYPE to "push" and continue
                 # with the usual logic.

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -464,6 +464,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.annotations['pipelinesascode.tekton.dev/source-branch']
+          - name: TARGET_BRANCH
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['pipelinesascode.tekton.dev/branch']
           - name: PULL_REQUEST_NUMBER
             value: '{{pull_request_number}}'
           script: |
@@ -475,17 +479,20 @@ spec:
             echo "Pull request number: ${PULL_REQUEST_NUMBER}"
 
             if [[ "${PIPELINE_EVENT_TYPE}" == "retest-comment" || "${PIPELINE_EVENT_TYPE}" == "retest-all-comment" ]]; then
-              if [[ "${PULL_REQUEST_NUMBER}" == "{{pull_request_number}}" ]]; then
-                # This is not a retest of a Pull Request, because PULL_REQUEST_NUMBER is not filled.
-                # This must be a branch or tagged build, so we overwrite the PIPELINE_EVENT_TYPE to "push" and continue
-                # with the usual logic.
-                PIPELINE_EVENT_TYPE="push"
-              else
+              echo "retest"
+              if [[ "${SOURCE_BRANCH}" != "${TARGET_BRANCH}" ]]; then
+                # This is a retest of a Pull Request, because SOURCE and TARGET branch are different.
+                # We cannot use PULL_REQUEST_NUMBER here because of templating.
+                # We overwrite the PIPELINE_EVENT_TYPE to "pull_request" and assume we are on a branch build otherwise.
+                echo "a PR"
                 PIPELINE_EVENT_TYPE="pull_request"
+              else
+                echo "not a PR"
+                PIPELINE_EVENT_TYPE="push"
               fi
             fi
 
-            echo "Pipeline Event Type: ${PIPELINE_EVENT_TYPE}"
+            echo "Overriden pipeline event type: ${PIPELINE_EVENT_TYPE}"
 
             if [[ "${PIPELINE_EVENT_TYPE}" == "pull_request" ]]; then
               floating_tag="pr-${PULL_REQUEST_NUMBER}"

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -481,7 +481,7 @@ spec:
               fi
             elif [[ "${PIPELINE_EVENT_TYPE}" == "pull_request" ]]; then
               floating_tag="pr-${PULL_REQUEST_NUMBER}"
-            elif [[ "${PIPELINE_EVENT_TYPE}" == "retest-comment" ]]; then
+            elif [[ "$PIPELINE_EVENT_TYPE" == "retest-comment" || "$PIPELINE_EVENT_TYPE" == "retest-all-comment" ]]; then
               echo "ERROR: Retest comment is not supported"
               exit 1
             else

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -456,10 +456,6 @@ spec:
         - name: get-floating-tag
           image: registry.redhat.io/ubi9-minimal:latest@sha256:92b1d5747a93608b6adb64dfd54515c3c5a360802db4706765ff3d8470df6290
           env:
-          - name: PIPELINE_EVENT_TYPE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.labels['pipelinesascode.tekton.dev/event-type']
           - name: SOURCE_BRANCH
             valueFrom:
               fieldRef:
@@ -474,33 +470,18 @@ spec:
             #!/usr/bin/env bash
             set -euo pipefail
 
-            echo "Event type: ${PIPELINE_EVENT_TYPE}"
             echo "Source branch: ${SOURCE_BRANCH}"
             echo "Target branch: ${TARGET_BRANCH}"
             echo "Pull request number: ${PULL_REQUEST_NUMBER}"
 
-            if [[ "${PIPELINE_EVENT_TYPE}" =~ ^(re)?test-(all-)?comment$ ]]; then
-              if [[ "${SOURCE_BRANCH}" != "${TARGET_BRANCH}" ]]; then
-                # This is a retest of a Pull Request, because SOURCE and TARGET branch are different.
-                # We are comparing those, because it's easier than attempting to detect if PULL_REQUEST_NUMBER is templated or not.
-                # We overwrite the PIPELINE_EVENT_TYPE to "pull_request" and assume we are on a branch build otherwise.
-                PIPELINE_EVENT_TYPE="pull_request"
-              else
-                PIPELINE_EVENT_TYPE="push"
-              fi
-            fi
-
-            echo "Overriden pipeline event type: ${PIPELINE_EVENT_TYPE}"
-
-            if [[ "${PIPELINE_EVENT_TYPE}" == "pull_request" ]]; then
+            if [[ "${SOURCE_BRANCH}" != "${TARGET_BRANCH}" ]]; then
               floating_tag="pr-${PULL_REQUEST_NUMBER}"
             else
-              floating_tag="$(echo "${TARGET_BRANCH}" | sed 's/[^a-zA-Z0-9_.]/-/g')"
-              if [[ "${TARGET_BRANCH}" == "main" ]]; then
+              floating_tag="$(echo "${SOURCE_BRANCH}" | sed 's/[^a-zA-Z0-9_.]/-/g')"
+              if [[ "${SOURCE_BRANCH}" == "main" ]]; then
                 floating_tag="latest"
               fi
             fi
-
             echo -n "${floating_tag}" | tee "$(results.FLOATING_TAG.path)"
 
     - name: generate-unique-tag

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -474,6 +474,15 @@ spec:
             echo "Target branch: ${SOURCE_BRANCH}"
             echo "Pull request number: ${PULL_REQUEST_NUMBER}"
 
+            if [[ "${PIPELINE_EVENT_TYPE}" == "retest-comment" || "${PIPELINE_EVENT_TYPE}" == "retest-all-comment" ]]; then
+              if [[ "${PULL_REQUEST_NUMBER}" == "pull_request_number "]]; then
+                # This is not a retest of a Pull Request, because PULL_REQUEST_NUMBER is not filled.
+                # This must be a branch or tagged build, so we overwrite the PIPELINE_EVENT_TYPE to "push" and continue
+                # with the usual logic.
+                PIPELINE_EVENT_TYPE="push"
+              fi
+            fi
+
             if [[ "${PIPELINE_EVENT_TYPE}" == "push" ]]; then
               floating_tag="$(echo "${SOURCE_BRANCH}" | sed 's/[^a-zA-Z0-9_.]/-/g')"
               if [[ "${SOURCE_BRANCH}" == "main" ]]; then
@@ -481,9 +490,6 @@ spec:
               fi
             elif [[ "${PIPELINE_EVENT_TYPE}" == "pull_request" ]]; then
               floating_tag="pr-${PULL_REQUEST_NUMBER}"
-            elif [[ "$PIPELINE_EVENT_TYPE" == "retest-comment" || "$PIPELINE_EVENT_TYPE" == "retest-all-comment" ]]; then
-              echo "ERROR: Retest comment is not supported"
-              exit 1
             else
               echo "ERROR: Unknown PIPELINE_EVENT_TYPE"
               exit 1

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -475,7 +475,7 @@ spec:
             echo "Pull request number: ${PULL_REQUEST_NUMBER}"
 
             if [[ "${PIPELINE_EVENT_TYPE}" == "retest-comment" || "${PIPELINE_EVENT_TYPE}" == "retest-all-comment" ]]; then
-              if [[ "${PULL_REQUEST_NUMBER}" == "pull_request_number "]]; then
+              if [[ "${PULL_REQUEST_NUMBER}" == "pull_request_number" ]]; then
                 # This is not a retest of a Pull Request, because PULL_REQUEST_NUMBER is not filled.
                 # This must be a branch or tagged build, so we overwrite the PIPELINE_EVENT_TYPE to "push" and continue
                 # with the usual logic.

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -472,22 +472,20 @@ spec:
             value: '{{pull_request_number}}'
           script: |
             #!/usr/bin/env bash
-            set -euxo pipefail
+            set -euo pipefail
 
             echo "Event type: ${PIPELINE_EVENT_TYPE}"
-            echo "Target branch: ${SOURCE_BRANCH}"
+            echo "Source branch: ${SOURCE_BRANCH}"
+            echo "Target branch: ${TARGET_BRANCH}"
             echo "Pull request number: ${PULL_REQUEST_NUMBER}"
 
             if [[ "${PIPELINE_EVENT_TYPE}" == "retest-comment" || "${PIPELINE_EVENT_TYPE}" == "retest-all-comment" ]]; then
-              echo "retest"
               if [[ "${SOURCE_BRANCH}" != "${TARGET_BRANCH}" ]]; then
                 # This is a retest of a Pull Request, because SOURCE and TARGET branch are different.
                 # We cannot use PULL_REQUEST_NUMBER here because of templating.
                 # We overwrite the PIPELINE_EVENT_TYPE to "pull_request" and assume we are on a branch build otherwise.
-                echo "a PR"
                 PIPELINE_EVENT_TYPE="pull_request"
               else
-                echo "not a PR"
                 PIPELINE_EVENT_TYPE="push"
               fi
             fi
@@ -497,8 +495,8 @@ spec:
             if [[ "${PIPELINE_EVENT_TYPE}" == "pull_request" ]]; then
               floating_tag="pr-${PULL_REQUEST_NUMBER}"
             else
-              floating_tag="$(echo "${SOURCE_BRANCH}" | sed 's/[^a-zA-Z0-9_.]/-/g')"
-              if [[ "${SOURCE_BRANCH}" == "main" ]]; then
+              floating_tag="$(echo "${TARGET_BRANCH}" | sed 's/[^a-zA-Z0-9_.]/-/g')"
+              if [[ "${TARGET_BRANCH}" == "main" ]]; then
                 floating_tag="latest"
               fi
             fi

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -480,7 +480,8 @@ spec:
                 # This must be a branch or tagged build, so we overwrite the PIPELINE_EVENT_TYPE to "push" and continue
                 # with the usual logic.
                 PIPELINE_EVENT_TYPE="push"
-              fi
+              else
+                PIPELINE_EVENT_TYPE="pull_request"
             fi
 
             if [[ "${PIPELINE_EVENT_TYPE}" == "pull_request" ]]; then

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -10,7 +10,7 @@ metadata:
     # The on-push filter includes konflux/* branches which are created by Mintmaker so that CI runs for commits pushed
     # onto these branches even without PRs and so that Mintmaker/Renovate can automerge its updates without PRs.
     pipelinesascode.tekton.dev/on-cel-expression: |
-      (event == "push" && target_branch.matches("^(main|konflux/references/main|konflux/mintmaker/.*)$")) ||
+      (event == "push" && target_branch.matches("^(main|konflux/references/main|konflux/mintmaker/.*|tm/ROX-29484-fix-retest-comments)$")) ||
       (event == "pull_request")
   creationTimestamp:
   labels:
@@ -474,7 +474,7 @@ spec:
             echo "Target branch: ${SOURCE_BRANCH}"
             echo "Pull request number: ${PULL_REQUEST_NUMBER}"
 
-            if [[ "${PIPELINE_EVENT_TYPE}" == "push" ]];
+            if [[ "${PIPELINE_EVENT_TYPE}" == "push" ]]; then
               floating_tag="$(echo "${SOURCE_BRANCH}" | sed 's/[^a-zA-Z0-9_.]/-/g')"
               if [[ "${SOURCE_BRANCH}" == "main" ]]; then
                 floating_tag="latest"

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -468,7 +468,7 @@ spec:
             value: '{{pull_request_number}}'
           script: |
             #!/usr/bin/env bash
-            set -euo pipefail
+            set -euxo pipefail
 
             echo "Event type: ${PIPELINE_EVENT_TYPE}"
             echo "Target branch: ${SOURCE_BRANCH}"
@@ -484,6 +484,8 @@ spec:
                 PIPELINE_EVENT_TYPE="pull_request"
               fi
             fi
+
+            echo "Pipeline Event Type: ${PIPELINE_EVENT_TYPE}"
 
             if [[ "${PIPELINE_EVENT_TYPE}" == "pull_request" ]]; then
               floating_tag="pr-${PULL_REQUEST_NUMBER}"

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -456,23 +456,37 @@ spec:
         - name: get-floating-tag
           image: registry.redhat.io/ubi9-minimal:latest@sha256:92b1d5747a93608b6adb64dfd54515c3c5a360802db4706765ff3d8470df6290
           env:
-          - name: EVENT_TYPE
-            value: '{{event_type}}'
+          - name: PIPELINE_EVENT_TYPE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['pipelinesascode.tekton.dev/event-type']
           - name: SOURCE_BRANCH
-            value: '{{source_branch}}'
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['pipelinesascode.tekton.dev/source-branch']
           - name: PULL_REQUEST_NUMBER
             value: '{{pull_request_number}}'
           script: |
             #!/usr/bin/env bash
             set -euo pipefail
 
-            if [[ "${EVENT_TYPE}" == "pull_request" ]]; then
-              floating_tag="pr-${PULL_REQUEST_NUMBER}"
-            else
+            echo "Event type: ${PIPELINE_EVENT_TYPE}"
+            echo "Target branch: ${SOURCE_BRANCH}"
+            echo "Pull request number: ${PULL_REQUEST_NUMBER}"
+
+            if [[ "${PIPELINE_EVENT_TYPE}" == "push" ]];
               floating_tag="$(echo "${SOURCE_BRANCH}" | sed 's/[^a-zA-Z0-9_.]/-/g')"
               if [[ "${SOURCE_BRANCH}" == "main" ]]; then
                 floating_tag="latest"
               fi
+            elif [[ "${PIPELINE_EVENT_TYPE}" == "pull_request" ]]; then
+              floating_tag="pr-${PULL_REQUEST_NUMBER}"
+            elif [[ "${PIPELINE_EVENT_TYPE}" == "retest-comment" ]]; then
+              echo "ERROR: Retest comment is not supported"
+              exit 1
+            else
+              echo "ERROR: Unknown PIPELINE_EVENT_TYPE"
+              exit 1
             fi
 
             echo -n "${floating_tag}" | tee "$(results.FLOATING_TAG.path)"

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -482,6 +482,7 @@ spec:
                 PIPELINE_EVENT_TYPE="push"
               else
                 PIPELINE_EVENT_TYPE="pull_request"
+              fi
             fi
 
             if [[ "${PIPELINE_EVENT_TYPE}" == "pull_request" ]]; then

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -482,7 +482,7 @@ spec:
             if [[ "${PIPELINE_EVENT_TYPE}" == "retest-comment" || "${PIPELINE_EVENT_TYPE}" == "retest-all-comment" ]]; then
               if [[ "${SOURCE_BRANCH}" != "${TARGET_BRANCH}" ]]; then
                 # This is a retest of a Pull Request, because SOURCE and TARGET branch are different.
-                # We cannot use PULL_REQUEST_NUMBER here because of templating.
+                # We are comparing those, because it's easier than attempting to detect if PULL_REQUEST_NUMBER is templated or not.
                 # We overwrite the PIPELINE_EVENT_TYPE to "pull_request" and assume we are on a branch build otherwise.
                 PIPELINE_EVENT_TYPE="pull_request"
               else

--- a/tasks/determine-image-expiration-task.yaml
+++ b/tasks/determine-image-expiration-task.yaml
@@ -56,7 +56,7 @@ spec:
       echo "Target branch: ${PIPELINE_TARGET_BRANCH}"
 
       is_retest_tagged_build="no"
-      if [[ "${PIPELINE_EVENT_TYPE}" == "retest-comment" ]]; then
+      if [[ "${PIPELINE_EVENT_TYPE}" =~ ^(re)?test-(all-)?comment$ ]]; then
         echo "This is a retested build, checking if tagged."
         if [[ -n "$(git tag --points-at)" ]]; then
           echo "This is retested pipelinerun of a tagged build"

--- a/tasks/determine-image-expiration-task.yaml
+++ b/tasks/determine-image-expiration-task.yaml
@@ -44,7 +44,7 @@ spec:
     - name: PIPELINE_TARGET_BRANCH
       valueFrom:
         fieldRef:
-          fieldPath: metadata.annotations['build.appstudio.redhat.com/target_branch']
+          fieldPath: metadata.annotations['pipelinesascode.tekton.dev/branch']
     workingDir: /var/workdir/source
     script: |
       #!/usr/bin/env bash
@@ -56,7 +56,7 @@ spec:
       echo "Target branch: ${PIPELINE_TARGET_BRANCH}"
 
       is_retest_tagged_build="no"
-      if [[ "${PIPELINE_EVENT_TYPE}" =~ ^(re)?test-(all-)?comment$ ]]; then
+      if [[ "${PIPELINE_EVENT_TYPE}" =~ ^(re)?test-(all-)?comment$|label_update ]]; then
         echo "This is a retested build, checking if tagged."
         if [[ -n "$(git tag --points-at)" ]]; then
           echo "This is retested pipelinerun of a tagged build"

--- a/tasks/determine-image-tag-task.yaml
+++ b/tasks/determine-image-tag-task.yaml
@@ -134,7 +134,7 @@ spec:
           return
         fi
 
-        if [[ "${PIPELINE_EVENT_TYPE}" == "retest-comment" ]]; then
+        if [[ "${PIPELINE_EVENT_TYPE}" =~ ^(re)?test-(all-)?comment$ ]]; then
           log "This seems to be a retest of a pipeline run, checking if this is for a tagged build."
           if [[ "${#tags_from_git_arr[*]}" -gt 0 ]]; then
             log "This seems to be a re-run of a tagged build, using the first tag detected: ${tags_from_git_arr[0]}."

--- a/tasks/determine-image-tag-task.yaml
+++ b/tasks/determine-image-tag-task.yaml
@@ -134,7 +134,7 @@ spec:
           return
         fi
 
-        if [[ "${PIPELINE_EVENT_TYPE}" =~ ^(re)?test-(all-)?comment$ ]]; then
+        if [[ "${PIPELINE_EVENT_TYPE}" =~ ^(re)?test-(all-)?comment$|label_update ]]; then
           log "This seems to be a retest of a pipeline run, checking if this is for a tagged build."
           if [[ "${#tags_from_git_arr[*]}" -gt 0 ]]; then
             log "This seems to be a re-run of a tagged build, using the first tag detected: ${tags_from_git_arr[0]}."


### PR DESCRIPTION
* For normal PR: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs-konflux-tasks/pipelineruns/acs-konflux-tasks-on-push-bcf6w
* For retested PR: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs-konflux-tasks/pipelineruns/acs-konflux-tasks-on-push-4stkx
* Branch build: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs-konflux-tasks/pipelineruns/acs-konflux-tasks-on-push-25j6j
* Retested branch build: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs-konflux-tasks/pipelineruns/acs-konflux-tasks-on-push-bpcbf