### PR TITLE
ROX-29411: wait-for-image waits for the attestation image to appear

### DIFF
--- a/tasks/wait-for-image-task.yaml
+++ b/tasks/wait-for-image-task.yaml
@@ -48,8 +48,11 @@ spec:
 
       # Output
       echo -n "${infos[0]}" | tee "$(results.IMAGE_DIGEST.path)"
+      echo
       echo -n "${infos[1]}" | tee "$(results.GIT_REF.path)"
+      echo
       echo -n "${infos[2]}" | tee "$(results.GIT_REPO.path)"
+      echo
 
       IMAGE_WITH_DIGEST="$(params.IMAGE)@${infos[0]}"
       echo "Waiting for attestation for ${IMAGE_WITH_DIGEST} to appear..."


### PR DESCRIPTION
In https://github.com/stackrox/stackrox/pull/15552, I used the updated task definition. 

Then, cancelled https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/pipelineruns/central-db-on-push-wlt6g after `build-image-index`, which produced `quay.io/rhacs-eng/release-central-db:4.8.0-908-ga3674ca73a-fast`. 

In a container of `registry.redhat.io/rhtas/cosign-rhel9:1.2.0-1744791100@sha256:cb53dcc3bc912dd7f12147f33af1b435eae5ff4ab83b85c0277b4004b20a0248`, I observe:

```
bash-5.1# cosign login quay.io --username ... --password ...
bash-5.1# cosign tree quay.io/rhacs-eng/release-central-db:4.8.0-908-ga3674ca73a-fast
📦 Supply Chain Security Related artifacts for an image: quay.io/rhacs-eng/release-central-db:4.8.0-908-ga3674ca73a-fast
└── 🔐 Signatures for an image tag: quay.io/rhacs-eng/release-central-db:sha256-65f7dfc0aa6dc185cd59f450ba9e47235fd0212aae4f9584fc7628dc39a83428.sig
   ├── 🍒 sha256:06449fe186e828e3d2afc98b7d75a4aa8724e28987f1fd108252c87c165989ef
   └── 🍒 sha256:06449fe186e828e3d2afc98b7d75a4aa8724e28987f1fd108252c87c165989ef
└── 📦 SBOMs for an image tag: quay.io/rhacs-eng/release-central-db:sha256-65f7dfc0aa6dc185cd59f450ba9e47235fd0212aae4f9584fc7628dc39a83428.sbom
   └── 🍒 sha256:e493a4a7a684cb51b47b61ef0464cf6bf2a6aecd156d1baf17a36ff921893234
```

Operator-bundle PR then failed as expected waiting for central-db image attestation: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/pipelineruns/operator-bundle-on-push-lwnmc