### PR TITLE
ROX-29484: Strip `refs/heads/` from the beginning of both branches

### DIFF
--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -470,6 +470,7 @@ spec:
             #!/usr/bin/env bash
             set -euo pipefail
 
+            # Normalize branch names because Konflux sometimes prepends refs/heads/ and sometimes doesn't.
             SOURCE_BRANCH="${SOURCE_BRANCH#refs/heads/}"
             TARGET_BRANCH="${TARGET_BRANCH#refs/heads/}"
 

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -470,6 +470,9 @@ spec:
             #!/usr/bin/env bash
             set -euo pipefail
 
+            SOURCE_BRANCH="${SOURCE_BRANCH#refs/heads/}"
+            TARGET_BRANCH="${TARGET_BRANCH#refs/heads/}"
+
             echo "Source branch: ${SOURCE_BRANCH}"
             echo "Target branch: ${TARGET_BRANCH}"
             echo "Pull request number: ${PULL_REQUEST_NUMBER}"


### PR DESCRIPTION
See https://redhat-internal.slack.com/archives/C05TS9N0S7L/p1749037676916069

### Validation

In https://github.com/stackrox/konflux-tasks/commit/e28dd60112200587e0c55bf6ef384f5aa283443e / <https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs-konflux-tasks/pipelineruns/acs-konflux-tasks-on-push-427hc>. `get-floating-tag` produced `misha-test-for-ROX-29484` despite `pipelinesascode.tekton.dev/source-branch=refs/heads/misha/test-for-ROX-29484`.