### PR TITLE
ROX-30075: Sanitize `.x` in git tags

### DIFF
--- a/tasks/determine-image-tag-task.yaml
+++ b/tasks/determine-image-tag-task.yaml
@@ -109,16 +109,6 @@ spec:
         tag_from_makefile="$(make -C "$(params.MAKEFILE_DIRECTORY)" --quiet --no-print-directory tag)"
         log "Tag reported by Makefile: '${tag_from_makefile}'"
 
-        # Fast Stream tags/versions must be comparable according to SemVer and so versions like '4.7.x-anything' should
-        # be converted to '4.7.0-anything'.
-        local tag_from_makefile_sanitized
-        tag_from_makefile_sanitized="$(echo "${tag_from_makefile}" | sed -E 's@^(([[:digit:]]+\.)+)x(-)?@\10\3@g' )"
-        log "Tag from Makefile with '.x' sanitized: '${tag_from_makefile_sanitized}'"
-
-        local stackrox_repo
-        stackrox_repo="$(is_stackrox_repo)"
-        log "Is this StackRox repo: ${stackrox_repo}"
-
         local tags_from_git
         tags_from_git="$(git tag --points-at)"
         local -a tags_from_git_arr
@@ -158,20 +148,33 @@ spec:
           return
         fi
 
-        # We sanitize StackRox tags for Fast Stream users so that versions are comparable according to SemVer.
-        # We must not sanitize tags for Collector and Scanner because these are internal, development tags (e.g.
-        # 3.20.x-80-g5afdaf059a and 2.35.x-57-ga9da3070bd) which are not exposed to users (and they must match the
-        # contents of COLLECTOR_VERSION and SCANNER_VERSION files); instead we add unified tags (same as on images built
-        # from StackRox repo, e.g. 4.7.0-551-g1ca8d0d66e-fast) to user-facing Collector and Scanner images (with
-        # retagging and/or release pipelines).
-        if [[ "${stackrox_repo}" == "yes" ]]; then
-          log "Using sanitized Makefile output ${tag_from_makefile_sanitized} for the tag."
-          echo "${tag_from_makefile_sanitized}"
+        log "Using Makefile output ${tag_from_makefile} for the tag."
+        sanitize_tag "${tag_from_makefile}"
+        return
+      }
+
+      # sanitize_tag changes '.x' to '.0' in StackRox repo tags and passes through tags for other repos as-is.
+      #
+      # Fast Stream tags/versions must be comparable according to SemVer and so versions like '4.7.x-anything' should
+      # be converted to '4.7.0-anything'.
+      # We must not sanitize tags for Collector and Scanner because these are internal, development tags (e.g.
+      # 3.20.x-80-g5afdaf059a and 2.35.x-57-ga9da3070bd) which are not exposed to users (and they must match the
+      # contents of COLLECTOR_VERSION and SCANNER_VERSION files); instead we add unified tags (same as on images built
+      # from StackRox repo, e.g. 4.7.0-551-g1ca8d0d66e-fast) to user-facing Collector and Scanner images (with
+      # retagging and/or release pipelines).
+      function sanitize_tag() {
+        local -r tag="$1"
+
+        local tag_sanitized
+        tag_sanitized="$(echo "${tag}" | sed -E 's@^(([[:digit:]]+\.)+)x(-)?@\10\3@g' )"
+
+        if [[ "$(is_stackrox_repo)" == "yes" && "${tag}" != "${tag_sanitized}" ]]; then
+          log "This is StackRox repo, using tag sanitized for '.x'->'.0' ${tag_sanitized}."
+          echo "${tag_sanitized}"
           return
         fi
 
-        log "Using Makefile output ${tag_from_makefile} for the tag."
-        echo "${tag_from_makefile}"
+        echo "${tag}"
         return
       }
 

--- a/tasks/determine-image-tag-task.yaml
+++ b/tasks/determine-image-tag-task.yaml
@@ -123,7 +123,7 @@ spec:
 
         if [[ -n "${tag_from_tekton}" ]]; then
           log "This seems to be a tekton tag push event, using ${tag_from_tekton} for the tag."
-          echo "${tag_from_tekton}"
+          sanitize_tag "${tag_from_tekton}"
           return
         fi
 
@@ -131,7 +131,7 @@ spec:
           log "This seems to be a retest of a pipeline run, checking if this is for a tagged build."
           if [[ "${#tags_from_git_arr[*]}" -gt 0 ]]; then
             log "This seems to be a re-run of a tagged build, using the first tag detected: ${tags_from_git_arr[0]}."
-            echo "${tags_from_git_arr[0]}"
+            sanitize_tag "${tags_from_git_arr[0]}"
             return
           else
             log "This is not a tagged build, so continuing with normal logic."

--- a/tasks/determine-image-tag-task.yaml
+++ b/tasks/determine-image-tag-task.yaml
@@ -122,7 +122,7 @@ spec:
         # 2. Decide
 
         if [[ -n "${tag_from_tekton}" ]]; then
-          log "This seems to be a tekton tag push event, using ${tag_from_tekton} for the tag."
+          log "This seems to be a tekton tag push event, using '${tag_from_tekton}' for the tag."
           sanitize_tag "${tag_from_tekton}"
           return
         fi
@@ -130,7 +130,7 @@ spec:
         if [[ "${PIPELINE_EVENT_TYPE}" =~ ^(re)?test-(all-)?comment$ ]]; then
           log "This seems to be a retest of a pipeline run, checking if this is for a tagged build."
           if [[ "${#tags_from_git_arr[*]}" -gt 0 ]]; then
-            log "This seems to be a re-run of a tagged build, using the first tag detected: ${tags_from_git_arr[0]}."
+            log "This seems to be a re-run of a tagged build, using the first tag detected: '${tags_from_git_arr[0]}'."
             sanitize_tag "${tags_from_git_arr[0]}"
             return
           else
@@ -143,12 +143,12 @@ spec:
           log "This is not a tag push event but Makefile reports literally the git tag '${tag_from_makefile}'."
           log "This happens when a build was triggered not by a tag push event but the commit is tagged and when the Makefile doesn't use '--long' with 'git describe'."
           log "We should use a different image tag for this build in order to not mix results with a build that was triggered by the tag push event and which will indeed use '${tag_from_makefile}' as the tag for images built there."
-          log "Using ${git_describe_output} for the tag."
+          log "Using '${git_describe_output}' for the tag."
           echo "${git_describe_output}"
           return
         fi
 
-        log "Using Makefile output ${tag_from_makefile} for the tag."
+        log "Using Makefile output '${tag_from_makefile}' for the tag."
         sanitize_tag "${tag_from_makefile}"
         return
       }
@@ -169,7 +169,7 @@ spec:
         tag_sanitized="$(echo "${tag}" | sed -E 's@^(([[:digit:]]+\.)+)x(-)?@\10\3@g' )"
 
         if [[ "$(is_stackrox_repo)" == "yes" && "${tag}" != "${tag_sanitized}" ]]; then
-          log "This is StackRox repo, using tag sanitized for '.x'->'.0' ${tag_sanitized}."
+          log "This is StackRox repo, using '.x'->'.0' sanitized tag '${tag_sanitized}'."
           echo "${tag_sanitized}"
           return
         fi


### PR DESCRIPTION
Per ticket.

### Validation

Via https://github.com/stackrox/stackrox/pull/15985 and https://github.com/stackrox/scanner/pull/1967.

In StackRox (not tagged) logs look like this (bash/go warning omitted):

```
>>> Target branch as reported by Tekton: 'master'
>>> Tag from Tekton: ''
>>> Tekton event: pull_request
>>> Tag reported by Makefile: '4.9.x-221-g7877f16eab'
>>> Tags seen by git: ''
>>> Long git describe output: '4.9.x-221-g7877f16eab'
>>> Using Makefile output '4.9.x-221-g7877f16eab' for the tag.
>>> This is StackRox repo, using '.x'->'.0' sanitized tag '4.9.0-221-g7877f16eab'.
>>> Konflux TARGET_BRANCH: master
>>> Konflux SOURCE_BRANCH: misha/ROX-30075-test-new-konflux-tags
>>> Did not spot the magic string in the SOURCE_BRANCH.
>>> This does not look like a release branch or release tag push, nor like PR targeting the release branch. Using '-fast' as the tag suffix.
4.9.0-221-g7877f16eab-fast
```

In Scanner repo (not tagged):

```
>>> Target branch as reported by Tekton: 'master'
>>> Tag from Tekton: ''
>>> Tekton event: pull_request
>>> Tag reported by Makefile: '2.37.x-14-gd08e89bc15'
>>> Tags seen by git: ''
>>> Long git describe output: '2.37.x-14-gd08e89bc15'
>>> Using Makefile output '2.37.x-14-gd08e89bc15' for the tag.
>>> This is not a StackRox repo, using '-fast' as the tag suffix.
2.37.x-14-gd08e89bc15-fast
```

StackRox commit tagged as `0.1.x-misha-test`:
```
>>> Target branch as reported by Tekton: 'refs/tags/0.1.x-misha-test'
>>> Tag from Tekton: '0.1.x-misha-test'
>>> Tekton event: push
>>> Tag reported by Makefile: '0.1.x-misha-test-0-gb78f480bfb'
>>> Tags seen by git: '0.1.x-misha-test'
>>> Long git describe output: '0.1.x-misha-test-0-gb78f480bfb'
>>> This seems to be a tekton tag push event, using '0.1.x-misha-test' for the tag.
>>> This is StackRox repo, using '.x'->'.0' sanitized tag '0.1.0-misha-test'.
>>> Konflux TARGET_BRANCH: refs/tags/0.1.x-misha-test
>>> Konflux SOURCE_BRANCH: refs/tags/0.1.x-misha-test
>>> Did not spot the magic string in the SOURCE_BRANCH.
>>> This does not look like a release branch or release tag push, nor like PR targeting the release branch. Using '-fast' as the tag suffix.
0.1.0-misha-test-fast
```

StackRox commit tagged as `0.1.6-misha-test`:
```
>>> Target branch as reported by Tekton: 'refs/tags/0.1.6-misha-test'
>>> Tag from Tekton: '0.1.6-misha-test'
>>> Tekton event: push
>>> Tag reported by Makefile: '0.1.6-misha-test-0-g5f00936104'
>>> Tags seen by git: '0.1.6-misha-test'
>>> Long git describe output: '0.1.6-misha-test-0-g5f00936104'
>>> This seems to be a tekton tag push event, using '0.1.6-misha-test' for the tag.
>>> Konflux TARGET_BRANCH: refs/tags/0.1.6-misha-test
>>> Konflux SOURCE_BRANCH: refs/tags/0.1.6-misha-test
>>> Did not spot the magic string in the SOURCE_BRANCH.
>>> This does not look like a release branch or release tag push, nor like PR targeting the release branch. Using '-fast' as the tag suffix.
0.1.6-misha-test-fast
```