### PR TITLE
perf: nosync and batch biqguery

### DIFF
--- a/tasks/post-bigquery-metrics-task.yaml
+++ b/tasks/post-bigquery-metrics-task.yaml
@@ -113,7 +113,8 @@ spec:
           sleep "${delay}"
         fi
 
-        if bq query \
+        if bq --nosync query \
+            --batch \
             --headless \
             --use_legacy_sql=false \
             --parameter="id::${ID}" \


### PR DESCRIPTION
Since bigquery insert is not critical maybe we can run it async and in batch mode.

See:
- https://github.com/stackrox/stackrox/pull/16052#discussion_r2211175747