### PR TITLE
ROX-29969: Update image expiration check to follow our release-like definition

### DIFF
--- a/tasks/determine-image-expiration-task.yaml
+++ b/tasks/determine-image-expiration-task.yaml
@@ -51,28 +51,21 @@ spec:
 
       set -euo pipefail
 
-      echo "Default image expiration: $(params.DEFAULT_IMAGE_EXPIRES_AFTER)"
+      IMAGE_EXPIRES_AFTER="$(params.DEFAULT_IMAGE_EXPIRES_AFTER)"
+      echo "Default image expiration: ${IMAGE_EXPIRES_AFTER}"
       echo "SOURCE_BRANCH: ${SOURCE_BRANCH}"
       echo "TARGET_BRANCH: ${TARGET_BRANCH}"
 
       # TODO(ROX-28001): Update the expiration logic for -fast releases.
 
-      # Normalize branch names because Konflux sometimes prepends refs/heads/ and sometimes doesn't.
-      # Similarly, we don't want to run into issues when Konflux puts refs/tags/ in one and forgets about the other.
-      SOURCE_BRANCH_SANITIZED="${SOURCE_BRANCH#refs/heads/}"
-      TARGET_BRANCH_SANITIZED="${TARGET_BRANCH#refs/heads/}"
-      SOURCE_BRANCH_SANITIZED="${SOURCE_BRANCH_SANITIZED#refs/tags/}"
-      TARGET_BRANCH_SANITIZED="${TARGET_BRANCH_SANITIZED#refs/tags/}"
-
-      if [[ "${SOURCE_BRANCH_SANITIZED}" == "${TARGET_BRANCH_SANITIZED}" && \
-        -n "$(git tag --points-at | grep -vF -- '-nightly-')" ]]; then
-        # The condition above reads as: this is not a PR and there's a git tag which is not nightly.
-        # We don't check for `refs/tags/*` in SOURCE|TARGET_BRANCH because it won't be there when the tagged build is
-        # re-triggered with /test or /retest comment.
-        echo "This is a tagged build and not a nightly. The images won't expire. IMAGE_EXPIRES_AFTER will be empty."
+      if [[ "${SOURCE_BRANCH}" == *konflux-release-like* ]]; then
+        >&2 echo "This looks like a PR branch containing the magic string. Images won't expire."
         IMAGE_EXPIRES_AFTER=""
-      else
-        IMAGE_EXPIRES_AFTER="$(params.DEFAULT_IMAGE_EXPIRES_AFTER)"
+      fi
+
+      if grep -qE '^((refs/heads/)?release-[0-9a-z]+\.[0-9a-z]+|refs/tags/[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?)$' <<< "${TARGET_BRANCH}"; then
+        >&2 echo "This looks like a release branch or release tag push, or PR targeting the release branch. Images won't expire."
+        IMAGE_EXPIRES_AFTER=""
       fi
 
       echo -n "${IMAGE_EXPIRES_AFTER}" | tee "$(results.IMAGE_EXPIRES_AFTER.path)"


### PR DESCRIPTION
## Description

Running the stage release pipeline reveals a new failure in Conforma.
```
✕ [Violation] quay_expiration.expires_label
  ImageRef: quay.io/rhacs-eng/release-scanner-v4-db@sha256:874194eb1765ccb7afbadc371ac2fc4c8eac406a5e974017d6030b18eba9f029
  Reason: The label 'quay.expires-after' is not allowed in the released image
  Title: Expires label
  Description: Check the image metadata for the presence of a "quay.expires-after" label. If it's present then produce a
  violation. This check is enforced only for a "release", "production", or "staging" pipeline, as determined by the value of the
  `pipeline_intention` rule data. To exclude this rule add "quay_expiration.expires_label" to the `exclude` section of the policy
  configuration.
  Solution: Make sure the image is built without setting the "quay.expires-after" label. This label is usually set if the
  container image was built by an "on-pr" pipeline during pre-merge CI.
```

I did it for Snapshot `acs-4-6-4-6-9-1-g4360c6b012-20250827t150455z` created from `release-4.6` **non-tagged** push (`"version": "4.6.9-1-g4360c6b012"`).

While this isn't a blocker for a prod release (the one should always be tagged), it's a blocker for a stage release as long as it's not tagged. Since I may have to iterate a few more times on the stage release, I see a value in adjusting our `determine-image-expiration` task to the same [_release-like_ definition](https://github.com/stackrox/architecture-decision-records/blob/main/releases/ADR-0002-konflux-image-repos-and-tags.md#-the-proposal) as `determine-image-tag` task already has.

In this PR I copy-pasted `if` conditions from the `determine-image-tag` task.
https://github.com/stackrox/konflux-tasks/blob/569a248d67325ed4dcebe5fba5ef11ce8acf6ddf/tasks/determine-image-tag-task.yaml#L194-L202

Related thread: <https://redhat-internal.slack.com/archives/C031USXS2FJ/p1756313100833939?thread_ts=1755622785.895239&cid=C031USXS2FJ>.

## Validation

* [PR](https://github.com/stackrox/scanner/pull/2098) against the release branch: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs-4-6/taskruns/scanner-on-push-4wwpm-determine-image-expiration/logs
```
step-determine-image-expiration
Default image expiration: 13w
SOURCE_BRANCH: misha/test-expiration-change
TARGET_BRANCH: release-2.35
This looks like a release branch or release tag push, or PR targeting the release branch. Images won't expire.
```

* [PR](https://github.com/stackrox/scanner/pull/2099) against master branch with PR branch containing `konflux-release-like` in the name: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/taskruns/scanner-on-push-psfhd-determine-image-expiration/logs
```
step-determine-image-expiration
Default image expiration: 13w
SOURCE_BRANCH: misha/test-expiration-change-konflux-release-like
TARGET_BRANCH: master
This looks like a PR branch containing the magic string. Images won't expire.
```

* Ordinary [PR](https://github.com/stackrox/scanner/pull/2100) against master branch: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/taskruns/scanner-on-push-lphzz-determine-image-expiration/logs
```
step-determine-image-expiration
Default image expiration: 13w
SOURCE_BRANCH: misha/test-expiration-konflux-ordinary
TARGET_BRANCH: master
13w
```

With that I saw each code branch hit at least once so I think it's sufficient provided that the `grep` expression was extensively tested before.