### PR TITLE
chore: Switch bq from async to sync

### DIFF
--- a/tasks/post-bigquery-metrics-task.yaml
+++ b/tasks/post-bigquery-metrics-task.yaml
@@ -115,7 +115,7 @@ spec:
           sleep "${delay}"
         fi
 
-        if bq --nosync query \
+        if bq --sync query \
             --batch \
             --headless \
             --use_legacy_sql=false \


### PR DESCRIPTION
## Description

Context: https://redhat-internal.slack.com/archives/C05TS9N0S7L/p1776881061200849

We're missing data from lots of pipelines and the optimization performed in https://github.com/stackrox/konflux-tasks/pull/71 does not let me see what's happening to bigquery. Do our requests fail? Do they suceed? No idea. This turns the sync mode back on so that we start having evidence in the logs.

I was pondering whether to prevent failing `bq` fail the task and the pipeline, here https://github.com/stackrox/konflux-tasks/blob/09a6f48c18c42fe248c99045c7ddb8a6b765a2be/tasks/post-bigquery-metrics-task.yaml#L143-L146
but we have retries and let's first see how it becomes a problem. Though, I'm open to suggestions.

## Testing

Ran pipelines in https://github.com/stackrox/stackrox/pull/20181 as a smoke test.