### PR TITLE
chore(ROX-34419): Switch to task-runner image

### DIFF
--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -459,7 +459,7 @@ spec:
         - name: BUNDLE_CONTENTS
         steps:
         - name: get-bundle-info
-          image: quay.io/konflux-ci/appstudio-utils:latest@sha256:f8eb4e08c6e4942ac4bdf1a2dc8869a7f1be630f90853369d311b991a9fd8039
+          image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
           script: |
             #!/usr/bin/env bash
             set -euo pipefail
@@ -497,7 +497,7 @@ spec:
           description: Image digest of the trust bundle artifact
         steps:
         - name: update-tasks-trust
-          image: quay.io/konflux-ci/appstudio-utils:latest@sha256:f8eb4e08c6e4942ac4bdf1a2dc8869a7f1be630f90853369d311b991a9fd8039
+          image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
           script: |
             #!/usr/bin/env bash
             set -euo pipefail

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -508,6 +508,9 @@ spec:
         steps:
         - name: update-tasks-trust
           image: quay.io/conforma/cli:latest@sha256:576df237c75266b45e277c0899eeb58f8338cf5efacba358de2ed9b962160f42
+          env:
+            - name: HOME
+              value: /tekton/home
           script: |
             #!/usr/bin/env bash
             set -euo pipefail

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -497,7 +497,7 @@ spec:
           description: Image digest of the trust bundle artifact
         steps:
         - name: update-tasks-trust
-          image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+          image: quay.io/conforma/cli:latest@sha256:576df237c75266b45e277c0899eeb58f8338cf5efacba358de2ed9b962160f42
           script: |
             #!/usr/bin/env bash
             set -euo pipefail
@@ -545,6 +545,16 @@ spec:
                 --bundle "$(params.BUNDLE_REF)" \
                 --output "oci:${trust_image_ref}"
             fi
+
+        - name: get-trust-bundle-image-digest
+          image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+          script: |
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            trust_image_tag="$(params.TRUST_IMAGE_TAG)"
+            trust_image_repo="$(params.TRUST_IMAGE_REPO)"
+            trust_image_ref="${trust_image_repo}:${trust_image_tag}"
 
             # Because this image is a custom type we can't use skopeo inspect, oras manifest or podman manifest inspect easily,
             # as they don't include the manifest of the artifact, only of the content layers.

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -507,7 +507,7 @@ spec:
           description: Image digest of the trust bundle artifact
         steps:
         - name: update-tasks-trust
-          image: quay.io/conforma/cli:latest@sha256:576df237c75266b45e277c0899eeb58f8338cf5efacba358de2ed9b962160f42
+          image: quay.io/conforma/cli:snapshot@sha256:5c65cd5de356e0954f3adad019974b27c11ff9cbd309b463f66d92d511c62c41
           env:
           # This is required to copy the docker creds to a writeable location.
           - name: HOME
@@ -560,7 +560,9 @@ spec:
                 --output "oci:${trust_image_ref}"
             fi
 
-        - name: get-trust-bundle-image-digest
+            echo ">>> Done"
+
+        - name: get-trust-bundle-digest
           image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
           script: |
             #!/usr/bin/env bash

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -509,6 +509,7 @@ spec:
         - name: update-tasks-trust
           image: quay.io/conforma/cli:latest@sha256:576df237c75266b45e277c0899eeb58f8338cf5efacba358de2ed9b962160f42
           env:
+            # This is required to copy the docker creds to a writeable location.
             - name: HOME
               value: /tekton/home
           script: |

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -563,7 +563,7 @@ spec:
             echo ">>> Done"
 
         - name: get-trust-bundle-digest
-          image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+          image: quay.io/konflux-ci/task-runner:1.5.0@sha256:200019314a50be5b6dd06f362c794c92a700583a522c5eee9a41e3eab7f706c5
           script: |
             #!/usr/bin/env bash
             set -euo pipefail

--- a/.tekton/acs-konflux-tasks-push.yaml
+++ b/.tekton/acs-konflux-tasks-push.yaml
@@ -509,9 +509,9 @@ spec:
         - name: update-tasks-trust
           image: quay.io/conforma/cli:latest@sha256:576df237c75266b45e277c0899eeb58f8338cf5efacba358de2ed9b962160f42
           env:
-            # This is required to copy the docker creds to a writeable location.
-            - name: HOME
-              value: /tekton/home
+          # This is required to copy the docker creds to a writeable location.
+          - name: HOME
+            value: /tekton/home
           script: |
             #!/usr/bin/env bash
             set -euo pipefail


### PR DESCRIPTION
Context: apputils-image is deprecated and won't receive further updates. https://groups.google.com/a/redhat.com/g/konflux/c/kL4bAgLbQ1E/m/k3SOivwrCAAJ

Unfortunately, the replacement task-runner image doesn't have `ec` CLI installed, so we use `quay.io/conforma/cli` for this (https://conforma.dev/docs/cli/release-process.html#_2_container_images). The `update-task-trust` task had to be split for this. 

# Validation

In https://github.com/stackrox/stackrox/pull/20418, I waited for the pipeline to produce the `central-db` image and used EC locally (since we don't have `acs-conforma-dev` ITS anymore).

The result didn't show untrusted tasks from `quay.io/rhacs-eng/konflux-tasks`. 

<details><summary>Details</summary>
<p>

```bash
ec validate image --image quay.io/rhacs-eng/release-central-db:4.11.0-902-g2ce3877cbc-fast --policy acs-conforma-dev --ignore-rekor
Success: false
Result: FAILURE
Violations: 37, Warnings: 103, Successes: 647

Components:
- Name: Unnamed-sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5-arm64
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Violations: 9, Warnings: 22, Successes: 129

- Name: Unnamed-sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a-amd64
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Violations: 9, Warnings: 22, Successes: 129

- Name: Unnamed
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1faefcec0a8ef2e262ed2a9dfe6c200677398da20063338d370fdd68f157fef0
  Violations: 1, Warnings: 15, Successes: 131

- Name: Unnamed-sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283-ppc64le
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Violations: 9, Warnings: 22, Successes: 129

- Name: Unnamed-sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9-s390x
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Violations: 9, Warnings: 22, Successes: 129

Results:
✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: Found "CVE-2026-1519" vulnerability of high security level
  Term: CVE-2026-1519

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: Found "CVE-2026-27135" vulnerability of high security level
  Term: CVE-2026-27135

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: Found "CVE-2026-33412" vulnerability of high security level
  Term: CVE-2026-33412

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: Found "CVE-2026-34982" vulnerability of high security level
  Term: CVE-2026-34982

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: Found "CVE-2026-4111" vulnerability of high security level
  Term: CVE-2026-4111

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: Found "CVE-2026-4424" vulnerability of high security level
  Term: CVE-2026-4424

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: Found "CVE-2026-4519" vulnerability of high security level
  Term: CVE-2026-4519

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: Found "CVE-2026-4878" vulnerability of high security level
  Term: CVE-2026-4878

✕ [Violation] slsa_source_correlated.source_code_reference_provided
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: Expected source code reference was not provided for verification

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: Found "CVE-2026-1519" vulnerability of high security level
  Term: CVE-2026-1519

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: Found "CVE-2026-27135" vulnerability of high security level
  Term: CVE-2026-27135

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: Found "CVE-2026-33412" vulnerability of high security level
  Term: CVE-2026-33412

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: Found "CVE-2026-34982" vulnerability of high security level
  Term: CVE-2026-34982

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: Found "CVE-2026-4111" vulnerability of high security level
  Term: CVE-2026-4111

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: Found "CVE-2026-4424" vulnerability of high security level
  Term: CVE-2026-4424

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: Found "CVE-2026-4519" vulnerability of high security level
  Term: CVE-2026-4519

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: Found "CVE-2026-4878" vulnerability of high security level
  Term: CVE-2026-4878

✕ [Violation] slsa_source_correlated.source_code_reference_provided
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: Expected source code reference was not provided for verification

✕ [Violation] slsa_source_correlated.source_code_reference_provided
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1faefcec0a8ef2e262ed2a9dfe6c200677398da20063338d370fdd68f157fef0
  Reason: Expected source code reference was not provided for verification

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: Found "CVE-2026-1519" vulnerability of high security level
  Term: CVE-2026-1519

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: Found "CVE-2026-27135" vulnerability of high security level
  Term: CVE-2026-27135

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: Found "CVE-2026-33412" vulnerability of high security level
  Term: CVE-2026-33412

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: Found "CVE-2026-34982" vulnerability of high security level
  Term: CVE-2026-34982

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: Found "CVE-2026-4111" vulnerability of high security level
  Term: CVE-2026-4111

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: Found "CVE-2026-4424" vulnerability of high security level
  Term: CVE-2026-4424

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: Found "CVE-2026-4519" vulnerability of high security level
  Term: CVE-2026-4519

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: Found "CVE-2026-4878" vulnerability of high security level
  Term: CVE-2026-4878

✕ [Violation] slsa_source_correlated.source_code_reference_provided
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: Expected source code reference was not provided for verification

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: Found "CVE-2026-1519" vulnerability of high security level
  Term: CVE-2026-1519

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: Found "CVE-2026-27135" vulnerability of high security level
  Term: CVE-2026-27135

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: Found "CVE-2026-33412" vulnerability of high security level
  Term: CVE-2026-33412

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: Found "CVE-2026-34982" vulnerability of high security level
  Term: CVE-2026-34982

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: Found "CVE-2026-4111" vulnerability of high security level
  Term: CVE-2026-4111

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: Found "CVE-2026-4424" vulnerability of high security level
  Term: CVE-2026-4424

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: Found "CVE-2026-4519" vulnerability of high security level
  Term: CVE-2026-4519

✕ [Violation] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: Found "CVE-2026-4878" vulnerability of high security level
  Term: CVE-2026-4878

✕ [Violation] slsa_source_correlated.source_code_reference_provided
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: Expected source code reference was not provided for verification

› [Warning] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: Found "CVE-2026-4786" vulnerability of high security level
  Term: CVE-2026-4786

› [Warning] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: Found "CVE-2026-6100" vulnerability of high security level
  Term: CVE-2026-6100

› [Warning] cve.unpatched_cve_warnings
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: Found "CVE-2026-33845" non-blocking unpatched vulnerability of high security level
  Term: CVE-2026-33845

› [Warning] cve.unpatched_cve_warnings
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: Found "CVE-2026-40356" non-blocking unpatched vulnerability of high security level
  Term: CVE-2026-40356

› [Warning] cve.unpatched_cve_warnings
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: Found "CVE-2026-41035" non-blocking unpatched vulnerability of high security level
  Term: CVE-2026-41035

› [Warning] cve.unpatched_cve_warnings
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: Found "CVE-2026-42010" non-blocking unpatched vulnerability of high security level
  Term: CVE-2026-42010

› [Warning] cve.unpatched_cve_warnings
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: Found "CVE-2026-6846" non-blocking unpatched vulnerability of high security level
  Term: CVE-2026-6846

› [Warning] test.no_failed_informative_tests
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: The Task "sast-shell-check-oci-ta" from the build Pipeline reports a failed informative test
  Term: sast-shell-check-oci-ta

› [Warning] test.no_failed_informative_tests
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: The Task "sast-snyk-check-oci-ta" from the build Pipeline reports a failed informative test
  Term: sast-snyk-check-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: A newer version of task "build-image-index" exists. Please update before 2026-05-31T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.2@sha256:c7b0f7e1f743040d99a3532abbdfddc9484f80fd559a75171c97499c3eb5d163"
  and the latest bundle ref is "sha256:020a1b4126cc6b7c7a919c2b549b94e6b7b826aaaa0d0f2e67d1980df967e498"
  Term: build-image-index

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: A newer version of task "build-images" exists. Please update before 2026-05-31T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.9@sha256:a9ca472e297388d6ef8d1f51ee205abee6076aed7c5356ec0df84f14a2e78ad8"
  and the latest bundle ref is "sha256:f667d1146533b1d49829c08097e31faf27db24563da576434a707353de62099f"
  Term: buildah-remote-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: A newer version of task "clair-scan" exists. Please update before 2026-05-23T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:59dec3000fa35c714d0209dc61e6ec9de15d4d45172246cf5eeff796c5cff65f"
  and the latest bundle ref is "sha256:8fad4c2e2f470f82ee43d6b2ac72327b4d9c6e9cb514a678911c1c9359c29894"
  Term: clair-scan

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: A newer version of task "clamav-scan" exists. Please update before 2026-06-14T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:9f18b216ce71a66909e7cb17d9b34526c02d73cf12884ba32d1f10614f7b9f5a"
  and the latest bundle ref is "sha256:567cb66bd2e1f4b58b9d4d756f3317fc62479e0b40aa0de66094b1f12d296cfc"
  Term: clamav-scan

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: A newer version of task "deprecated-base-image-check" exists. Please update before 2026-06-27T00:00:00Z. The current
  bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:5ff16b7e6b4a8aa1adb352e74b9f831f77ff97bafd1b89ddb0038d63335f1a67"
  and the latest bundle ref is "sha256:e78d0d3baf3c8cfc1a5ad278196b74032d9568b143a87c7a79ab780fedfb296e"
  Term: deprecated-image-check

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: A newer version of task "ecosystem-cert-preflight-checks" exists. Please update before 2026-06-14T00:00:00Z. The current
  bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:b4ac586edea81dcd25dfc17f1bd57899825be2b443e48d572cd05ce058f153bb"
  and the latest bundle ref is "sha256:e2bcf1174a6dae9969b8f12e94babe2a5881bc77a509f10823b6a9eac6392850"
  Term: ecosystem-cert-preflight-checks

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: A newer version of task "clone-repository" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:2c388d28651457db60bb90287e7d8c3680303197196e4476878d98d81e8b6dc9"
  and the latest bundle ref is "sha256:13d49df7dc9ae301627e45f95a236011422996152f1bea46cd60217b0f057407"
  Term: git-clone-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: A newer version of task "init" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:288f3106118edc1d0f0c79a89c960abf5841a4dd8bc3f38feb10527253105b19"
  and the latest bundle ref is "sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08"
  Term: init

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: A newer version of task "prefetch-dependencies" exists. Please update before 2026-05-27T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:a579d00fe370b6d9a1cb1751c883ecd0ec9f663604344e2fd61e1f6d5bf4e990"
  and the latest bundle ref is "sha256:a2efbcdcecfa5293a622eb356a18f5c88e5714046b214fe8730b43b1a7dbb77d"
  Term: prefetch-dependencies-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: A newer version of task "push-dockerfile" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:1bc2d0f26b89259db090a47bb38217c82c05e335d626653d184adf1d196ca131"
  and the latest bundle ref is "sha256:7855471abfe87de080b914f2f3ca27c59e64f6448a7c2435e51435b764494c71"
  Term: push-dockerfile-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: A newer version of task "sast-shell-check" exists. Please update before 2026-05-29T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:6f047f52c04ee6e4d2cb25af46e3ea92b235f6c5e02da540fb7ef0b90718bc0a"
  and the latest bundle ref is "sha256:c4ef47e3b4e0508572d266fb745be7e374c29dc02580328cbe9f4d472a8aca57"
  Term: sast-shell-check-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: A newer version of task "show-sbom" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:04994df487ee886adbe60a8a5866647fbdfd53cc26f7b2554272ba51bf7af29e"
  and the latest bundle ref is "sha256:a7346ed61237db4f82ff782e0c9e8b30536e0e67b907ad600341a6d192e80012"
  Term: show-sbom

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:563568c22ae73caa94c299b23aee3e8d12f14c32939cad29931fdafb23efe8b5
  Reason: A newer version of task "build-source-image" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:362f0475df00e7dfb5f15dea0481d1b68b287f60411718d70a23da3c059a5613"
  and the latest bundle ref is "sha256:0917cfc7772e82cb8e74743c2104f43bcf2596aceafe87eec6fce69a8cac5f06"
  Term: source-build-oci-ta

› [Warning] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: Found "CVE-2026-4786" vulnerability of high security level
  Term: CVE-2026-4786

› [Warning] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: Found "CVE-2026-6100" vulnerability of high security level
  Term: CVE-2026-6100

› [Warning] cve.unpatched_cve_warnings
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: Found "CVE-2026-33845" non-blocking unpatched vulnerability of high security level
  Term: CVE-2026-33845

› [Warning] cve.unpatched_cve_warnings
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: Found "CVE-2026-40356" non-blocking unpatched vulnerability of high security level
  Term: CVE-2026-40356

› [Warning] cve.unpatched_cve_warnings
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: Found "CVE-2026-41035" non-blocking unpatched vulnerability of high security level
  Term: CVE-2026-41035

› [Warning] cve.unpatched_cve_warnings
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: Found "CVE-2026-42010" non-blocking unpatched vulnerability of high security level
  Term: CVE-2026-42010

› [Warning] cve.unpatched_cve_warnings
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: Found "CVE-2026-6846" non-blocking unpatched vulnerability of high security level
  Term: CVE-2026-6846

› [Warning] test.no_failed_informative_tests
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: The Task "sast-shell-check-oci-ta" from the build Pipeline reports a failed informative test
  Term: sast-shell-check-oci-ta

› [Warning] test.no_failed_informative_tests
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: The Task "sast-snyk-check-oci-ta" from the build Pipeline reports a failed informative test
  Term: sast-snyk-check-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: A newer version of task "build-image-index" exists. Please update before 2026-05-31T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.2@sha256:c7b0f7e1f743040d99a3532abbdfddc9484f80fd559a75171c97499c3eb5d163"
  and the latest bundle ref is "sha256:020a1b4126cc6b7c7a919c2b549b94e6b7b826aaaa0d0f2e67d1980df967e498"
  Term: build-image-index

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: A newer version of task "build-images" exists. Please update before 2026-05-31T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.9@sha256:a9ca472e297388d6ef8d1f51ee205abee6076aed7c5356ec0df84f14a2e78ad8"
  and the latest bundle ref is "sha256:f667d1146533b1d49829c08097e31faf27db24563da576434a707353de62099f"
  Term: buildah-remote-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: A newer version of task "clair-scan" exists. Please update before 2026-05-23T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:59dec3000fa35c714d0209dc61e6ec9de15d4d45172246cf5eeff796c5cff65f"
  and the latest bundle ref is "sha256:8fad4c2e2f470f82ee43d6b2ac72327b4d9c6e9cb514a678911c1c9359c29894"
  Term: clair-scan

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: A newer version of task "clamav-scan" exists. Please update before 2026-06-14T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:9f18b216ce71a66909e7cb17d9b34526c02d73cf12884ba32d1f10614f7b9f5a"
  and the latest bundle ref is "sha256:567cb66bd2e1f4b58b9d4d756f3317fc62479e0b40aa0de66094b1f12d296cfc"
  Term: clamav-scan

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: A newer version of task "deprecated-base-image-check" exists. Please update before 2026-06-27T00:00:00Z. The current
  bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:5ff16b7e6b4a8aa1adb352e74b9f831f77ff97bafd1b89ddb0038d63335f1a67"
  and the latest bundle ref is "sha256:e78d0d3baf3c8cfc1a5ad278196b74032d9568b143a87c7a79ab780fedfb296e"
  Term: deprecated-image-check

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: A newer version of task "ecosystem-cert-preflight-checks" exists. Please update before 2026-06-14T00:00:00Z. The current
  bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:b4ac586edea81dcd25dfc17f1bd57899825be2b443e48d572cd05ce058f153bb"
  and the latest bundle ref is "sha256:e2bcf1174a6dae9969b8f12e94babe2a5881bc77a509f10823b6a9eac6392850"
  Term: ecosystem-cert-preflight-checks

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: A newer version of task "clone-repository" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:2c388d28651457db60bb90287e7d8c3680303197196e4476878d98d81e8b6dc9"
  and the latest bundle ref is "sha256:13d49df7dc9ae301627e45f95a236011422996152f1bea46cd60217b0f057407"
  Term: git-clone-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: A newer version of task "init" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:288f3106118edc1d0f0c79a89c960abf5841a4dd8bc3f38feb10527253105b19"
  and the latest bundle ref is "sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08"
  Term: init

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: A newer version of task "prefetch-dependencies" exists. Please update before 2026-05-27T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:a579d00fe370b6d9a1cb1751c883ecd0ec9f663604344e2fd61e1f6d5bf4e990"
  and the latest bundle ref is "sha256:a2efbcdcecfa5293a622eb356a18f5c88e5714046b214fe8730b43b1a7dbb77d"
  Term: prefetch-dependencies-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: A newer version of task "push-dockerfile" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:1bc2d0f26b89259db090a47bb38217c82c05e335d626653d184adf1d196ca131"
  and the latest bundle ref is "sha256:7855471abfe87de080b914f2f3ca27c59e64f6448a7c2435e51435b764494c71"
  Term: push-dockerfile-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: A newer version of task "sast-shell-check" exists. Please update before 2026-05-29T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:6f047f52c04ee6e4d2cb25af46e3ea92b235f6c5e02da540fb7ef0b90718bc0a"
  and the latest bundle ref is "sha256:c4ef47e3b4e0508572d266fb745be7e374c29dc02580328cbe9f4d472a8aca57"
  Term: sast-shell-check-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: A newer version of task "show-sbom" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:04994df487ee886adbe60a8a5866647fbdfd53cc26f7b2554272ba51bf7af29e"
  and the latest bundle ref is "sha256:a7346ed61237db4f82ff782e0c9e8b30536e0e67b907ad600341a6d192e80012"
  Term: show-sbom

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:374ff6866db9aff3a38f1cbe60ecca2ad18d339b84f147e1ddab9debe6c0d97a
  Reason: A newer version of task "build-source-image" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:362f0475df00e7dfb5f15dea0481d1b68b287f60411718d70a23da3c059a5613"
  and the latest bundle ref is "sha256:0917cfc7772e82cb8e74743c2104f43bcf2596aceafe87eec6fce69a8cac5f06"
  Term: source-build-oci-ta

› [Warning] test.no_failed_informative_tests
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1faefcec0a8ef2e262ed2a9dfe6c200677398da20063338d370fdd68f157fef0
  Reason: The Task "sast-shell-check-oci-ta" from the build Pipeline reports a failed informative test
  Term: sast-shell-check-oci-ta

› [Warning] test.no_failed_informative_tests
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1faefcec0a8ef2e262ed2a9dfe6c200677398da20063338d370fdd68f157fef0
  Reason: The Task "sast-snyk-check-oci-ta" from the build Pipeline reports a failed informative test
  Term: sast-snyk-check-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1faefcec0a8ef2e262ed2a9dfe6c200677398da20063338d370fdd68f157fef0
  Reason: A newer version of task "build-image-index" exists. Please update before 2026-05-31T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.2@sha256:c7b0f7e1f743040d99a3532abbdfddc9484f80fd559a75171c97499c3eb5d163"
  and the latest bundle ref is "sha256:020a1b4126cc6b7c7a919c2b549b94e6b7b826aaaa0d0f2e67d1980df967e498"
  Term: build-image-index

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1faefcec0a8ef2e262ed2a9dfe6c200677398da20063338d370fdd68f157fef0
  Reason: A newer version of task "build-images" exists. Please update before 2026-05-31T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.9@sha256:a9ca472e297388d6ef8d1f51ee205abee6076aed7c5356ec0df84f14a2e78ad8"
  and the latest bundle ref is "sha256:f667d1146533b1d49829c08097e31faf27db24563da576434a707353de62099f"
  Term: buildah-remote-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1faefcec0a8ef2e262ed2a9dfe6c200677398da20063338d370fdd68f157fef0
  Reason: A newer version of task "clair-scan" exists. Please update before 2026-05-23T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:59dec3000fa35c714d0209dc61e6ec9de15d4d45172246cf5eeff796c5cff65f"
  and the latest bundle ref is "sha256:8fad4c2e2f470f82ee43d6b2ac72327b4d9c6e9cb514a678911c1c9359c29894"
  Term: clair-scan

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1faefcec0a8ef2e262ed2a9dfe6c200677398da20063338d370fdd68f157fef0
  Reason: A newer version of task "clamav-scan" exists. Please update before 2026-06-14T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:9f18b216ce71a66909e7cb17d9b34526c02d73cf12884ba32d1f10614f7b9f5a"
  and the latest bundle ref is "sha256:567cb66bd2e1f4b58b9d4d756f3317fc62479e0b40aa0de66094b1f12d296cfc"
  Term: clamav-scan

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1faefcec0a8ef2e262ed2a9dfe6c200677398da20063338d370fdd68f157fef0
  Reason: A newer version of task "deprecated-base-image-check" exists. Please update before 2026-06-27T00:00:00Z. The current
  bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:5ff16b7e6b4a8aa1adb352e74b9f831f77ff97bafd1b89ddb0038d63335f1a67"
  and the latest bundle ref is "sha256:e78d0d3baf3c8cfc1a5ad278196b74032d9568b143a87c7a79ab780fedfb296e"
  Term: deprecated-image-check

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1faefcec0a8ef2e262ed2a9dfe6c200677398da20063338d370fdd68f157fef0
  Reason: A newer version of task "ecosystem-cert-preflight-checks" exists. Please update before 2026-06-14T00:00:00Z. The current
  bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:b4ac586edea81dcd25dfc17f1bd57899825be2b443e48d572cd05ce058f153bb"
  and the latest bundle ref is "sha256:e2bcf1174a6dae9969b8f12e94babe2a5881bc77a509f10823b6a9eac6392850"
  Term: ecosystem-cert-preflight-checks

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1faefcec0a8ef2e262ed2a9dfe6c200677398da20063338d370fdd68f157fef0
  Reason: A newer version of task "clone-repository" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:2c388d28651457db60bb90287e7d8c3680303197196e4476878d98d81e8b6dc9"
  and the latest bundle ref is "sha256:13d49df7dc9ae301627e45f95a236011422996152f1bea46cd60217b0f057407"
  Term: git-clone-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1faefcec0a8ef2e262ed2a9dfe6c200677398da20063338d370fdd68f157fef0
  Reason: A newer version of task "init" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:288f3106118edc1d0f0c79a89c960abf5841a4dd8bc3f38feb10527253105b19"
  and the latest bundle ref is "sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08"
  Term: init

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1faefcec0a8ef2e262ed2a9dfe6c200677398da20063338d370fdd68f157fef0
  Reason: A newer version of task "prefetch-dependencies" exists. Please update before 2026-05-27T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:a579d00fe370b6d9a1cb1751c883ecd0ec9f663604344e2fd61e1f6d5bf4e990"
  and the latest bundle ref is "sha256:a2efbcdcecfa5293a622eb356a18f5c88e5714046b214fe8730b43b1a7dbb77d"
  Term: prefetch-dependencies-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1faefcec0a8ef2e262ed2a9dfe6c200677398da20063338d370fdd68f157fef0
  Reason: A newer version of task "push-dockerfile" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:1bc2d0f26b89259db090a47bb38217c82c05e335d626653d184adf1d196ca131"
  and the latest bundle ref is "sha256:7855471abfe87de080b914f2f3ca27c59e64f6448a7c2435e51435b764494c71"
  Term: push-dockerfile-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1faefcec0a8ef2e262ed2a9dfe6c200677398da20063338d370fdd68f157fef0
  Reason: A newer version of task "sast-shell-check" exists. Please update before 2026-05-29T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:6f047f52c04ee6e4d2cb25af46e3ea92b235f6c5e02da540fb7ef0b90718bc0a"
  and the latest bundle ref is "sha256:c4ef47e3b4e0508572d266fb745be7e374c29dc02580328cbe9f4d472a8aca57"
  Term: sast-shell-check-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1faefcec0a8ef2e262ed2a9dfe6c200677398da20063338d370fdd68f157fef0
  Reason: A newer version of task "show-sbom" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:04994df487ee886adbe60a8a5866647fbdfd53cc26f7b2554272ba51bf7af29e"
  and the latest bundle ref is "sha256:a7346ed61237db4f82ff782e0c9e8b30536e0e67b907ad600341a6d192e80012"
  Term: show-sbom

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1faefcec0a8ef2e262ed2a9dfe6c200677398da20063338d370fdd68f157fef0
  Reason: A newer version of task "build-source-image" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:362f0475df00e7dfb5f15dea0481d1b68b287f60411718d70a23da3c059a5613"
  and the latest bundle ref is "sha256:0917cfc7772e82cb8e74743c2104f43bcf2596aceafe87eec6fce69a8cac5f06"
  Term: source-build-oci-ta

› [Warning] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: Found "CVE-2026-4786" vulnerability of high security level
  Term: CVE-2026-4786

› [Warning] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: Found "CVE-2026-6100" vulnerability of high security level
  Term: CVE-2026-6100

› [Warning] cve.unpatched_cve_warnings
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: Found "CVE-2026-33845" non-blocking unpatched vulnerability of high security level
  Term: CVE-2026-33845

› [Warning] cve.unpatched_cve_warnings
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: Found "CVE-2026-40356" non-blocking unpatched vulnerability of high security level
  Term: CVE-2026-40356

› [Warning] cve.unpatched_cve_warnings
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: Found "CVE-2026-41035" non-blocking unpatched vulnerability of high security level
  Term: CVE-2026-41035

› [Warning] cve.unpatched_cve_warnings
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: Found "CVE-2026-42010" non-blocking unpatched vulnerability of high security level
  Term: CVE-2026-42010

› [Warning] cve.unpatched_cve_warnings
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: Found "CVE-2026-6846" non-blocking unpatched vulnerability of high security level
  Term: CVE-2026-6846

› [Warning] test.no_failed_informative_tests
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: The Task "sast-shell-check-oci-ta" from the build Pipeline reports a failed informative test
  Term: sast-shell-check-oci-ta

› [Warning] test.no_failed_informative_tests
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: The Task "sast-snyk-check-oci-ta" from the build Pipeline reports a failed informative test
  Term: sast-snyk-check-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: A newer version of task "build-image-index" exists. Please update before 2026-05-31T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.2@sha256:c7b0f7e1f743040d99a3532abbdfddc9484f80fd559a75171c97499c3eb5d163"
  and the latest bundle ref is "sha256:020a1b4126cc6b7c7a919c2b549b94e6b7b826aaaa0d0f2e67d1980df967e498"
  Term: build-image-index

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: A newer version of task "build-images" exists. Please update before 2026-05-31T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.9@sha256:a9ca472e297388d6ef8d1f51ee205abee6076aed7c5356ec0df84f14a2e78ad8"
  and the latest bundle ref is "sha256:f667d1146533b1d49829c08097e31faf27db24563da576434a707353de62099f"
  Term: buildah-remote-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: A newer version of task "clair-scan" exists. Please update before 2026-05-23T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:59dec3000fa35c714d0209dc61e6ec9de15d4d45172246cf5eeff796c5cff65f"
  and the latest bundle ref is "sha256:8fad4c2e2f470f82ee43d6b2ac72327b4d9c6e9cb514a678911c1c9359c29894"
  Term: clair-scan

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: A newer version of task "clamav-scan" exists. Please update before 2026-06-14T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:9f18b216ce71a66909e7cb17d9b34526c02d73cf12884ba32d1f10614f7b9f5a"
  and the latest bundle ref is "sha256:567cb66bd2e1f4b58b9d4d756f3317fc62479e0b40aa0de66094b1f12d296cfc"
  Term: clamav-scan

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: A newer version of task "deprecated-base-image-check" exists. Please update before 2026-06-27T00:00:00Z. The current
  bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:5ff16b7e6b4a8aa1adb352e74b9f831f77ff97bafd1b89ddb0038d63335f1a67"
  and the latest bundle ref is "sha256:e78d0d3baf3c8cfc1a5ad278196b74032d9568b143a87c7a79ab780fedfb296e"
  Term: deprecated-image-check

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: A newer version of task "ecosystem-cert-preflight-checks" exists. Please update before 2026-06-14T00:00:00Z. The current
  bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:b4ac586edea81dcd25dfc17f1bd57899825be2b443e48d572cd05ce058f153bb"
  and the latest bundle ref is "sha256:e2bcf1174a6dae9969b8f12e94babe2a5881bc77a509f10823b6a9eac6392850"
  Term: ecosystem-cert-preflight-checks

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: A newer version of task "clone-repository" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:2c388d28651457db60bb90287e7d8c3680303197196e4476878d98d81e8b6dc9"
  and the latest bundle ref is "sha256:13d49df7dc9ae301627e45f95a236011422996152f1bea46cd60217b0f057407"
  Term: git-clone-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: A newer version of task "init" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:288f3106118edc1d0f0c79a89c960abf5841a4dd8bc3f38feb10527253105b19"
  and the latest bundle ref is "sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08"
  Term: init

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: A newer version of task "prefetch-dependencies" exists. Please update before 2026-05-27T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:a579d00fe370b6d9a1cb1751c883ecd0ec9f663604344e2fd61e1f6d5bf4e990"
  and the latest bundle ref is "sha256:a2efbcdcecfa5293a622eb356a18f5c88e5714046b214fe8730b43b1a7dbb77d"
  Term: prefetch-dependencies-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: A newer version of task "push-dockerfile" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:1bc2d0f26b89259db090a47bb38217c82c05e335d626653d184adf1d196ca131"
  and the latest bundle ref is "sha256:7855471abfe87de080b914f2f3ca27c59e64f6448a7c2435e51435b764494c71"
  Term: push-dockerfile-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: A newer version of task "sast-shell-check" exists. Please update before 2026-05-29T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:6f047f52c04ee6e4d2cb25af46e3ea92b235f6c5e02da540fb7ef0b90718bc0a"
  and the latest bundle ref is "sha256:c4ef47e3b4e0508572d266fb745be7e374c29dc02580328cbe9f4d472a8aca57"
  Term: sast-shell-check-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: A newer version of task "show-sbom" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:04994df487ee886adbe60a8a5866647fbdfd53cc26f7b2554272ba51bf7af29e"
  and the latest bundle ref is "sha256:a7346ed61237db4f82ff782e0c9e8b30536e0e67b907ad600341a6d192e80012"
  Term: show-sbom

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:1832607b11673ed3b4609696cfa0748265d139735b91bbd2a3ecbaf0c56cb283
  Reason: A newer version of task "build-source-image" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:362f0475df00e7dfb5f15dea0481d1b68b287f60411718d70a23da3c059a5613"
  and the latest bundle ref is "sha256:0917cfc7772e82cb8e74743c2104f43bcf2596aceafe87eec6fce69a8cac5f06"
  Term: source-build-oci-ta

› [Warning] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: Found "CVE-2026-4786" vulnerability of high security level
  Term: CVE-2026-4786

› [Warning] cve.cve_blockers
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: Found "CVE-2026-6100" vulnerability of high security level
  Term: CVE-2026-6100

› [Warning] cve.unpatched_cve_warnings
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: Found "CVE-2026-33845" non-blocking unpatched vulnerability of high security level
  Term: CVE-2026-33845

› [Warning] cve.unpatched_cve_warnings
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: Found "CVE-2026-40356" non-blocking unpatched vulnerability of high security level
  Term: CVE-2026-40356

› [Warning] cve.unpatched_cve_warnings
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: Found "CVE-2026-41035" non-blocking unpatched vulnerability of high security level
  Term: CVE-2026-41035

› [Warning] cve.unpatched_cve_warnings
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: Found "CVE-2026-42010" non-blocking unpatched vulnerability of high security level
  Term: CVE-2026-42010

› [Warning] cve.unpatched_cve_warnings
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: Found "CVE-2026-6846" non-blocking unpatched vulnerability of high security level
  Term: CVE-2026-6846

› [Warning] test.no_failed_informative_tests
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: The Task "sast-shell-check-oci-ta" from the build Pipeline reports a failed informative test
  Term: sast-shell-check-oci-ta

› [Warning] test.no_failed_informative_tests
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: The Task "sast-snyk-check-oci-ta" from the build Pipeline reports a failed informative test
  Term: sast-snyk-check-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: A newer version of task "build-image-index" exists. Please update before 2026-05-31T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.2@sha256:c7b0f7e1f743040d99a3532abbdfddc9484f80fd559a75171c97499c3eb5d163"
  and the latest bundle ref is "sha256:020a1b4126cc6b7c7a919c2b549b94e6b7b826aaaa0d0f2e67d1980df967e498"
  Term: build-image-index

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: A newer version of task "build-images" exists. Please update before 2026-05-31T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.9@sha256:a9ca472e297388d6ef8d1f51ee205abee6076aed7c5356ec0df84f14a2e78ad8"
  and the latest bundle ref is "sha256:f667d1146533b1d49829c08097e31faf27db24563da576434a707353de62099f"
  Term: buildah-remote-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: A newer version of task "clair-scan" exists. Please update before 2026-05-23T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:59dec3000fa35c714d0209dc61e6ec9de15d4d45172246cf5eeff796c5cff65f"
  and the latest bundle ref is "sha256:8fad4c2e2f470f82ee43d6b2ac72327b4d9c6e9cb514a678911c1c9359c29894"
  Term: clair-scan

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: A newer version of task "clamav-scan" exists. Please update before 2026-06-14T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:9f18b216ce71a66909e7cb17d9b34526c02d73cf12884ba32d1f10614f7b9f5a"
  and the latest bundle ref is "sha256:567cb66bd2e1f4b58b9d4d756f3317fc62479e0b40aa0de66094b1f12d296cfc"
  Term: clamav-scan

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: A newer version of task "deprecated-base-image-check" exists. Please update before 2026-06-27T00:00:00Z. The current
  bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:5ff16b7e6b4a8aa1adb352e74b9f831f77ff97bafd1b89ddb0038d63335f1a67"
  and the latest bundle ref is "sha256:e78d0d3baf3c8cfc1a5ad278196b74032d9568b143a87c7a79ab780fedfb296e"
  Term: deprecated-image-check

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: A newer version of task "ecosystem-cert-preflight-checks" exists. Please update before 2026-06-14T00:00:00Z. The current
  bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:b4ac586edea81dcd25dfc17f1bd57899825be2b443e48d572cd05ce058f153bb"
  and the latest bundle ref is "sha256:e2bcf1174a6dae9969b8f12e94babe2a5881bc77a509f10823b6a9eac6392850"
  Term: ecosystem-cert-preflight-checks

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: A newer version of task "clone-repository" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:2c388d28651457db60bb90287e7d8c3680303197196e4476878d98d81e8b6dc9"
  and the latest bundle ref is "sha256:13d49df7dc9ae301627e45f95a236011422996152f1bea46cd60217b0f057407"
  Term: git-clone-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: A newer version of task "init" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:288f3106118edc1d0f0c79a89c960abf5841a4dd8bc3f38feb10527253105b19"
  and the latest bundle ref is "sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08"
  Term: init

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: A newer version of task "prefetch-dependencies" exists. Please update before 2026-05-27T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:a579d00fe370b6d9a1cb1751c883ecd0ec9f663604344e2fd61e1f6d5bf4e990"
  and the latest bundle ref is "sha256:a2efbcdcecfa5293a622eb356a18f5c88e5714046b214fe8730b43b1a7dbb77d"
  Term: prefetch-dependencies-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: A newer version of task "push-dockerfile" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:1bc2d0f26b89259db090a47bb38217c82c05e335d626653d184adf1d196ca131"
  and the latest bundle ref is "sha256:7855471abfe87de080b914f2f3ca27c59e64f6448a7c2435e51435b764494c71"
  Term: push-dockerfile-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: A newer version of task "sast-shell-check" exists. Please update before 2026-05-29T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:6f047f52c04ee6e4d2cb25af46e3ea92b235f6c5e02da540fb7ef0b90718bc0a"
  and the latest bundle ref is "sha256:c4ef47e3b4e0508572d266fb745be7e374c29dc02580328cbe9f4d472a8aca57"
  Term: sast-shell-check-oci-ta

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: A newer version of task "show-sbom" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:04994df487ee886adbe60a8a5866647fbdfd53cc26f7b2554272ba51bf7af29e"
  and the latest bundle ref is "sha256:a7346ed61237db4f82ff782e0c9e8b30536e0e67b907ad600341a6d192e80012"
  Term: show-sbom

› [Warning] trusted_task.current
  ImageRef: quay.io/rhacs-eng/release-central-db@sha256:0ede5c99b113bb28db0d34a51ba39e0ceada6aa0161955f3c55344ed143e8db9
  Reason: A newer version of task "build-source-image" exists. Please update before 2026-06-15T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:362f0475df00e7dfb5f15dea0481d1b68b287f60411718d70a23da3c059a5613"
  and the latest bundle ref is "sha256:0917cfc7772e82cb8e74743c2104f43bcf2596aceafe87eec6fce69a8cac5f06"
  Term: source-build-oci-ta

Error: success criteria not met
```

</p>
</details> 