### PR TITLE
ROX-34438: Fix metric reporting for push jobs

### DIFF
--- a/tasks/post-bigquery-metrics-task.yaml
+++ b/tasks/post-bigquery-metrics-task.yaml
@@ -95,7 +95,7 @@ spec:
       gcloud config set project "${GCP_PROJECT}"
 
       # Konflux/PaC tends to report PR number on PR merge commits which is then misleading in our data because push
-      # jobs wrongly appear belonging to PRs. Zero out PR number in this case.
+      # jobs wrongly appear belonging to PRs. Zero out PR number to prevent this.
       if [[ "${SOURCE_BRANCH}" == "${TARGET_BRANCH}" ]]; then
         PULL_REQUEST_NUMBER=""
       fi

--- a/tasks/post-bigquery-metrics-task.yaml
+++ b/tasks/post-bigquery-metrics-task.yaml
@@ -68,6 +68,11 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.annotations['pipelinesascode.tekton.dev/source-branch']
+    - name: TARGET_BRANCH
+      # E.g. "master"
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.annotations['pipelinesascode.tekton.dev/branch']
     - name: PULL_REQUEST_NUMBER
       # E.g. "14577"
       valueFrom:
@@ -88,6 +93,12 @@ spec:
 
       gcloud auth activate-service-account --key-file /mnt/gcp-service-account/konflux-metrics-gcp-service-account
       gcloud config set project "${GCP_PROJECT}"
+
+      # Konflux/PaC tends to report PR number on PR merge commits which is then misleading in our data because push
+      # jobs wrongly appear belonging to PRs. Zero out PR number in this case.
+      if [[ "${SOURCE_BRANCH}" == "${TARGET_BRANCH}" ]]; then
+        PULL_REQUEST_NUMBER=""
+      fi
 
       AGGREGATE_TASKS_STATUS="$(params.AGGREGATE_TASKS_STATUS)"
 


### PR DESCRIPTION
Context in https://redhat-internal.slack.com/archives/C05TS9N0S7L/p1776881061200849

### Testing

It's more like a smoke test because the actual results will appear only after some PR targeted at `master` _gets merged_, but I hope it's enough to show that it does not blow up and should work as expected.

#### PR build

Via https://github.com/stackrox/stackrox/pull/20278.

https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/pipelineruns/operator-bundle-on-push-ngzrg

`pr_number` is provided:
<img width="1498" height="606" alt="image" src="https://github.com/user-attachments/assets/0085dc7a-33a5-4a62-937d-93d93002f5dd" />


#### Push build

Via [release-misha-test-push-metric](https://github.com/stackrox/stackrox/commits/release-misha-test-push-metric/) branch.

https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/pipelineruns/operator-bundle-on-push-6q5vq

`pr_number` is empty:
<img width="1552" height="607" alt="image" src="https://github.com/user-attachments/assets/cd56ee5e-4098-4d0f-8514-a9413700480c" />
