### PR TITLE
fix(mintmaker): Set MintMaker PRs to always get recreated

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,6 +32,8 @@
       ".tekton/**",
       "tasks/**",
     ],
+    "recreateWhen": "always",
+    "rebaseWhen": "behind-base-branch",
     "schedule": [
       // For some reason, Konflux config defines custom schedule on each type of dependency manager and that takes
       // precedence over the global/default schedule. We want our own schedule and hence need to make this override.


### PR DESCRIPTION
## Description

I compared https://github.com/stackrox/konflux-tasks/pull/108
<img width="560" height="91" alt="image" src="https://github.com/user-attachments/assets/4c4a010b-b8fb-4f95-95ec-4c589d9305d7" />

and https://github.com/stackrox/operator-index/pull/426
<img width="614" height="88" alt="image" src="https://github.com/user-attachments/assets/d918599a-ce08-4f89-a297-297607a4b63b" />

and realized the change similar to https://github.com/stackrox/fact/pull/941 is needed in this repo.

## Validation

Just ran the local config validator and saw it's happy.