### PR TITLE
fix: Remove GIT_REF/GIT_REPO use in wait-for-image

### DIFF
--- a/tasks/wait-for-image-task.yaml
+++ b/tasks/wait-for-image-task.yaml
@@ -80,10 +80,6 @@ spec:
       # Output
       echo -n "${digest}" | tee "$(results.IMAGE_DIGEST.path)"
       echo
-      echo -n "${git_ref_from_label}" | tee "$(results.GIT_REF.path)"
-      echo
-      echo -n "${repository_from_label}" | tee "$(results.GIT_REPO.path)"
-      echo
 
       echo "Waiting for attestation for ${IMAGE_WITH_DIGEST} to appear..."
       while true; do


### PR DESCRIPTION
Context: https://redhat-internal.slack.com/archives/C0AB40QSUDS/p1784122735468099
Output params were removed in https://github.com/stackrox/konflux-tasks/pull/107 but their usage remained.

Validation: will repurpose https://github.com/stackrox/stackrox/pull/21170