### PR TITLE
ROX-35947: support SLSA attestation v1 format in wait-for-image

### DIFF
--- a/tasks/wait-for-image-task.yaml
+++ b/tasks/wait-for-image-task.yaml
@@ -113,22 +113,28 @@ spec:
           | length
         ' "${att_file}")"
       elif [[ "${predicate_type}" == "${v1_predicate_type}" ]]; then
-        not_success_count="$(jq '
-          [
-            .predicate.buildDefinition.resolvedDependencies[]
-            | select(has("content"))
-            | .content
-            | @base64d
-            | fromjson
-            | select(
-                (.status.conditions[] | select(.type == "Succeeded") | .status) != "True"
-              )
-          ]
-          | length
-        ' "${att_file}")"
-      else
-          >&2 echo "ERROR: Unknown predicate type: ${predicate_type}"
+        build_type="$(jq -r '.predicate.buildDefinition.buildType' "${att_file}")"
+        if [[ "${build_type}" == "https://tekton.dev/chains/v2/slsa-tekton" ]]; then
+          not_success_count="$(jq '
+            [
+              .predicate.buildDefinition.resolvedDependencies[]
+              | select(has("content"))
+              | .content
+              | @base64d
+              | fromjson
+              | select(
+                  ([.status.conditions[]? | select(.type == "Succeeded" and .status == "True")] | length) == 0
+                )
+            ]
+            | length
+          ' "${att_file}")"
+        else
+          >&2 echo "ERROR: Unknown build type: ${build_type}"
           exit 1
+        fi
+      else
+        >&2 echo "ERROR: Unknown predicate type: ${predicate_type}"
+        exit 1
       fi
 
       if [[ "${not_success_count}" -gt 0 ]]; then

--- a/tasks/wait-for-image-task.yaml
+++ b/tasks/wait-for-image-task.yaml
@@ -92,13 +92,46 @@ spec:
 
       echo "Attestion for ${IMAGE_WITH_DIGEST} found, which means PipelineRun finished. Checking if any tasks finished unsuccessfully."
 
-      no_success="$(cosign download attestation "${IMAGE_WITH_DIGEST}" | \
-        jq -r '.payload' | \
-        base64 -d | \
-        jq '.predicate.buildConfig.tasks | [ .[] | select(.status != "Succeeded") ] | length'
-      )"
+      att_file="$(mktemp)"
+      v02_predicate_type="https://slsa.dev/provenance/v0.2"
+      v1_predicate_type="https://slsa.dev/provenance/v1"
 
-      if [[ "${no_success}" -gt 0 ]]; then
+      cosign download attestation "${IMAGE_WITH_DIGEST}" | \
+        jq -r '.payload' | \
+        base64 -d > "${att_file}"
+
+      predicate_type="$(jq -r '.predicateType' "${att_file}")"
+      echo "Predicate type of the attestation: ${predicate_type}"
+      not_success_count=0
+
+      if [[ "${predicate_type}" == "${v02_predicate_type}" ]]; then
+        not_success_count="$(jq '
+          [
+            .predicate.buildConfig.tasks[]
+            | select(.status != "Succeeded")
+          ]
+          | length
+        ' "${att_file}")"
+      elif [[ "${predicate_type}" == "${v1_predicate_type}" ]]; then
+        not_success_count="$(jq '
+          [
+            .predicate.buildDefinition.resolvedDependencies[]
+            | select(has("content"))
+            | .content
+            | @base64d
+            | fromjson
+            | select(
+                (.status.conditions[] | select(.type == "Succeeded") | .status) != "True"
+              )
+          ]
+          | length
+        ' "${att_file}")"
+      else
+          >&2 echo "ERROR: Unknown predicate type: ${predicate_type}"
+          exit 1
+      fi
+
+      if [[ "${not_success_count}" -gt 0 ]]; then
         >&2 echo "ERROR: At least one task has failed during build of ${IMAGE_WITH_DIGEST}."
         >&2 echo "ERROR: This image will likely fail Conforma checks. Try building it again and re-run this pipeline."
         exit 1

--- a/tasks/wait-for-image-task.yaml
+++ b/tasks/wait-for-image-task.yaml
@@ -102,7 +102,6 @@ spec:
 
       predicate_type="$(jq -r '.predicateType' "${att_file}")"
       echo "Predicate type of the attestation: ${predicate_type}"
-      not_success_count=0
 
       if [[ "${predicate_type}" == "${v02_predicate_type}" ]]; then
         not_success_count="$(jq '

--- a/tasks/wait-for-image-task.yaml
+++ b/tasks/wait-for-image-task.yaml
@@ -90,7 +90,7 @@ spec:
         sleep 1m
       done
 
-      echo "Attestion for ${IMAGE_WITH_DIGEST} found, which means PipelineRun finished. Checking if any tasks finished unsuccessfully."
+      echo "Attestation for ${IMAGE_WITH_DIGEST} found, which means PipelineRun finished. Checking if any tasks finished unsuccessfully."
 
       att_file="$(mktemp)"
       v02_predicate_type="https://slsa.dev/provenance/v0.2"

--- a/tasks/wait-for-image-task.yaml
+++ b/tasks/wait-for-image-task.yaml
@@ -117,7 +117,7 @@ spec:
           not_succeeded_count="$(jq '
             [
               .predicate.buildDefinition.resolvedDependencies[]
-              | select(has("content"))
+              | select(.name == "pipelineTask")
               | .content
               | @base64d
               | fromjson

--- a/tasks/wait-for-image-task.yaml
+++ b/tasks/wait-for-image-task.yaml
@@ -104,7 +104,7 @@ spec:
       echo "Predicate type of the attestation: ${predicate_type}"
 
       if [[ "${predicate_type}" == "${v02_predicate_type}" ]]; then
-        not_success_count="$(jq '
+        not_succeeded_count="$(jq '
           [
             .predicate.buildConfig.tasks[]
             | select(.status != "Succeeded")
@@ -114,7 +114,7 @@ spec:
       elif [[ "${predicate_type}" == "${v1_predicate_type}" ]]; then
         build_type="$(jq -r '.predicate.buildDefinition.buildType' "${att_file}")"
         if [[ "${build_type}" == "https://tekton.dev/chains/v2/slsa-tekton" ]]; then
-          not_success_count="$(jq '
+          not_succeeded_count="$(jq '
             [
               .predicate.buildDefinition.resolvedDependencies[]
               | select(has("content"))
@@ -136,7 +136,7 @@ spec:
         exit 1
       fi
 
-      if [[ "${not_success_count}" -gt 0 ]]; then
+      if [[ "${not_succeeded_count}" -gt 0 ]]; then
         >&2 echo "ERROR: At least one task has failed during build of ${IMAGE_WITH_DIGEST}."
         >&2 echo "ERROR: This image will likely fail Conforma checks. Try building it again and re-run this pipeline."
         exit 1


### PR DESCRIPTION
* v0.2 format: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/pipelineruns/operator-bundle-on-push-mj9qs/ (https://github.com/stackrox/stackrox/pull/22007)
* v1 format in staging Konflux cluster: 
  * https://github.com/stackrox/konflux-tasks-validation/commit/8379daaddbd2a77c3c7bd7e2c257baee36d509a6 (successful run)
  * https://github.com/stackrox/konflux-tasks-validation/commit/a1aaaf39090c834807a3d450a63ce2eba56ae1bb (pipeline failure after image was published)

Both predicate types are supported by the new task.